### PR TITLE
Apply image updates to CronJob objects

### DIFF
--- a/pkg/update/testdata/leave/expected/cronjob.yaml
+++ b/pkg/update/testdata/leave/expected/cronjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: c
+            image: helloworld:v1.0.0

--- a/pkg/update/testdata/leave/original/cronjob.yaml
+++ b/pkg/update/testdata/leave/original/cronjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: c
+            image: helloworld:v1.0.0

--- a/pkg/update/testdata/replace/expected/cronjob.yaml
+++ b/pkg/update/testdata/replace/expected/cronjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: c
+            image: used:v1.1.0

--- a/pkg/update/testdata/replace/original/cronjob.yaml
+++ b/pkg/update/testdata/replace/original/cronjob.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: foo
+  namespace: bar
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: c
+            image: used:v1.0.0


### PR DESCRIPTION
This updates the image replacement to switch on the kind of the node,
and change the way the replacements are done for CronJobs.

CronJobs have PodTemplateSpecs embedded deeper in the structure.

This addresses #12 