### PR TITLE
Towards Toolkit compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Set up Go
-      uses: actions/setup-go@v2-beta
+      uses: actions/setup-go@v2
       with:
-        go-version: 1.14.x
+        go-version: 1.15.x
     - name: Set up kubebuilder
       # TODO replace with ../pkg/.. when that's merged
       uses: fluxcd/pkg/actions/kubebuilder@v0.0.4

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= fluxcd/image-automation-controller
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+# Produce CRDs that work back to Kubernetes 1.16
+CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Version of the Toolkit from which to get CRDs. Change this if you
 # bump the go module version.

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,10 +8,6 @@ metadata:
   creationTimestamp: null
   name: imageupdateautomations.image.toolkit.fluxcd.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.lastAutomationRunTime
-    name: Last run
-    type: string
   group: image.toolkit.fluxcd.io
   names:
     kind: ImageUpdateAutomation
@@ -19,111 +15,115 @@ spec:
     plural: imageupdateautomations
     singular: imageupdateautomation
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ImageUpdateAutomation is the Schema for the imageupdateautomations
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
-          properties:
-            checkout:
-              description: Checkout gives the parameters for cloning the git repository,
-                ready to make changes.
-              properties:
-                branch:
-                  description: Branch gives the branch to clone from the git repository.
-                    If missing, it will be left to default; be aware this may give
-                    indeterminate results.
-                  type: string
-                gitRepositoryRef:
-                  description: GitRepositoryRef refers to the resource giving access
-                    details to a git repository to update files in.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-              required:
-              - gitRepositoryRef
-              type: object
-            commit:
-              description: Commit specifies how to commit to the git repo
-              properties:
-                authorEmail:
-                  description: AuthorEmail gives the email to provide when making
-                    a commit
-                  type: string
-                authorName:
-                  description: AuthorName gives the name to provide when making a
-                    commit
-                  type: string
-                messageTemplate:
-                  description: MessageTemplate provides a template for the commit
-                    message, into which will be interpolated the details of the change
-                    made.
-                  type: string
-              required:
-              - authorEmail
-              - authorName
-              type: object
-            minimumRunInterval:
-              description: RunInterval gives a lower bound for how often the automation
-                run should be attempted. Otherwise it will default.
-              type: string
-            update:
-              description: Update gives the specification for how to update the files
-                in the repository
-              properties:
-                setters:
-                  description: Setters if present means update workloads using setters,
-                    via fields marked in the files themselves.
-                  properties:
-                    paths:
-                      description: Paths gives all paths that should be subject to
-                        updates using setters. If missing, the path `.` (the root
-                        of the git repository) is assumed.
-                      items:
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          required:
-          - checkout
-          - commit
-          - update
-          type: object
-        status:
-          description: ImageUpdateAutomationStatus defines the observed state of ImageUpdateAutomation
-          properties:
-            lastAutomationRunTime:
-              description: LastAutomationRunTime records the last time the controller
-                ran this automation through to completion (even if no updates were
-                made).
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.lastAutomationRunTime
+      name: Last run
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ImageUpdateAutomation is the Schema for the imageupdateautomations
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
+            properties:
+              checkout:
+                description: Checkout gives the parameters for cloning the git repository,
+                  ready to make changes.
+                properties:
+                  branch:
+                    description: Branch gives the branch to clone from the git repository.
+                      If missing, it will be left to default; be aware this may give
+                      indeterminate results.
+                    type: string
+                  gitRepositoryRef:
+                    description: GitRepositoryRef refers to the resource giving access
+                      details to a git repository to update files in.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                required:
+                - gitRepositoryRef
+                type: object
+              commit:
+                description: Commit specifies how to commit to the git repo
+                properties:
+                  authorEmail:
+                    description: AuthorEmail gives the email to provide when making
+                      a commit
+                    type: string
+                  authorName:
+                    description: AuthorName gives the name to provide when making
+                      a commit
+                    type: string
+                  messageTemplate:
+                    description: MessageTemplate provides a template for the commit
+                      message, into which will be interpolated the details of the
+                      change made.
+                    type: string
+                required:
+                - authorEmail
+                - authorName
+                type: object
+              minimumRunInterval:
+                description: RunInterval gives a lower bound for how often the automation
+                  run should be attempted. Otherwise it will default.
+                type: string
+              update:
+                description: Update gives the specification for how to update the
+                  files in the repository
+                properties:
+                  setters:
+                    description: Setters if present means update workloads using setters,
+                      via fields marked in the files themselves.
+                    properties:
+                      paths:
+                        description: Paths gives all paths that should be subject
+                          to updates using setters. If missing, the path `.` (the
+                          root of the git repository) is assumed.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            required:
+            - checkout
+            - commit
+            - update
+            type: object
+          status:
+            description: ImageUpdateAutomationStatus defines the observed state of
+              ImageUpdateAutomation
+            properties:
+              lastAutomationRunTime:
+                description: LastAutomationRunTime records the last time the controller
+                  ran this automation through to completion (even if no updates were
+                  made).
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,7 +1,7 @@
-resources:
-- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+- manager.yaml
 images:
 - name: controller
   newName: fluxcd/image-automation-controller

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: image-automation-controller
   labels:
-    control-plane: controller-manager
+    control-plane: controller
 spec:
   selector:
     matchLabels:
@@ -13,19 +13,38 @@ spec:
     metadata:
       labels:
         app: image-automation-controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
+      terminationGracePeriodSeconds: 10
       containers:
-      - command:
-        - /manager
+      - name: manager
+        image: fluxcd/image-automation-controller
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        ports:
+          - containerPort: 8080
+            name: http-prom
+        env:
+          - name: RUNTIME_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         args:
         - --enable-leader-election
-        image: fluxcd/image-automation-controller
-        name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 1Gi
           requests:
             cpu: 100m
-            memory: 20Mi
-      terminationGracePeriodSeconds: 10
+            memory: 64Mi
+        volumeMounts:
+          - name: temp
+            mountPath: /tmp
+      volumes:
+        - name: temp
+          emptyDir: {}


### PR DESCRIPTION
Changes:
- Generate CRDs using the stable apiextensions
- Update go to 1.5
- Use alpine as base image for multi-arch builds
- Set readonly FS and mount `/tmp`
- Expose Prometheus metrics endpoint

Things that should be addressed in other PRs:
- structured logging
- events
- watch-all-namespaces toggle
- liveness/readiness probes with controller-runtime
- multi-arch build and release workflow
- e2e tests with Kubernetes Kind 