### PR TITLE
Fix order of copy api/ and go mod in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,17 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+
+# This has its own go.mod, which needs to be present so go mod
+# download works.
+COPY api/ api/
+
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
 COPY pkg/ pkg/
 COPY controllers/ controllers/
 


### PR DESCRIPTION
Once the api/ directory has its own module, to which the top go.mod refers, it needs to be copied over before running `go mod download`.
