### PR TITLE
RunInterval -> Interval

### DIFF
--- a/api/v1alpha1/imageupdateautomation_types.go
+++ b/api/v1alpha1/imageupdateautomation_types.go
@@ -29,10 +29,10 @@ type ImageUpdateAutomationSpec struct {
 	// ready to make changes.
 	// +required
 	Checkout GitCheckoutSpec `json:"checkout"`
-	// RunInterval gives a lower bound for how often the automation
-	// run should be attempted. Otherwise it will default.
-	// +optional
-	RunInterval *metav1.Duration `json:"minimumRunInterval,omitempty"`
+	// Interval gives an lower bound for how often the automation
+	// run should be attempted.
+	// +required
+	Interval metav1.Duration `json:"interval"`
 	// Update gives the specification for how to update the files in
 	// the repository
 	// +required

--- a/api/v1alpha1/imageupdateautomation_types.go
+++ b/api/v1alpha1/imageupdateautomation_types.go
@@ -23,6 +23,8 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 )
 
+const ImageUpdateAutomationKind = "ImageUpdateAutomation"
+
 // ImageUpdateAutomationSpec defines the desired state of ImageUpdateAutomation
 type ImageUpdateAutomationSpec struct {
 	// Checkout gives the parameters for cloning the git repository,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -119,11 +119,7 @@ func (in *ImageUpdateAutomationList) DeepCopyObject() runtime.Object {
 func (in *ImageUpdateAutomationSpec) DeepCopyInto(out *ImageUpdateAutomationSpec) {
 	*out = *in
 	out.Checkout = in.Checkout
-	if in.RunInterval != nil {
-		in, out := &in.RunInterval, &out.RunInterval
-		*out = new(v1.Duration)
-		**out = **in
-	}
+	out.Interval = in.Interval
 	in.Update.DeepCopyInto(&out.Update)
 	out.Commit = in.Commit
 }

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -82,9 +82,9 @@ spec:
                 - authorEmail
                 - authorName
                 type: object
-              minimumRunInterval:
-                description: RunInterval gives a lower bound for how often the automation
-                  run should be attempted. Otherwise it will default.
+              interval:
+                description: Interval gives an lower bound for how often the automation
+                  run should be attempted.
                 type: string
               suspend:
                 description: Suspend tells the controller to not run this automation,
@@ -110,6 +110,7 @@ spec:
             required:
             - checkout
             - commit
+            - interval
             - update
             type: object
           status:

--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -57,8 +57,6 @@ import (
 	"github.com/fluxcd/image-automation-controller/pkg/update"
 )
 
-const defaultInterval = 2 * time.Minute
-
 // log level for debug info
 const debug = 1
 const originRemote = "origin"
@@ -249,10 +247,10 @@ func (r *ImageUpdateAutomationReconciler) SetupWithManager(mgr ctrl.Manager) err
 
 // intervalOrDefault gives the interval specified, or if missing, the default
 func intervalOrDefault(auto *imagev1.ImageUpdateAutomation) time.Duration {
-	if auto.Spec.RunInterval != nil {
-		return auto.Spec.RunInterval.Duration
+	if auto.Spec.Interval.Duration < time.Second {
+		return time.Second
 	}
-	return defaultInterval
+	return auto.Spec.Interval.Duration
 }
 
 // durationSinceLastRun calculates how long it's been since the last

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -210,7 +210,7 @@ var _ = Describe("ImageUpdateAutomation", func() {
 						Namespace: updateKey.Namespace,
 					},
 					Spec: imagev1.ImageUpdateAutomationSpec{
-						RunInterval: &metav1.Duration{Duration: 2 * time.Hour}, // this is to ensure any subsequent run should be outside the scope of the testing
+						Interval: metav1.Duration{Duration: 2 * time.Hour}, // this is to ensure any subsequent run should be outside the scope of the testing
 						Checkout: imagev1.GitCheckoutSpec{
 							GitRepositoryRef: corev1.LocalObjectReference{
 								Name: gitRepoKey.Name,

--- a/docs/api/image-automation.md
+++ b/docs/api/image-automation.md
@@ -172,7 +172,7 @@ ready to make changes.</p>
 </tr>
 <tr>
 <td>
-<code>minimumRunInterval</code><br>
+<code>interval</code><br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 Kubernetes meta/v1.Duration
@@ -180,9 +180,8 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>RunInterval gives a lower bound for how often the automation
-run should be attempted. Otherwise it will default.</p>
+<p>Interval gives an lower bound for how often the automation
+run should be attempted.</p>
 </td>
 </tr>
 <tr>
@@ -210,6 +209,19 @@ CommitSpec
 </td>
 <td>
 <p>Commit specifies how to commit to the git repo</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Suspend tells the controller to not run this automation, until
+it is unset (or set to false). Defaults to false.</p>
 </td>
 </tr>
 </table>
@@ -264,7 +276,7 @@ ready to make changes.</p>
 </tr>
 <tr>
 <td>
-<code>minimumRunInterval</code><br>
+<code>interval</code><br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 Kubernetes meta/v1.Duration
@@ -272,9 +284,8 @@ Kubernetes meta/v1.Duration
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>RunInterval gives a lower bound for how often the automation
-run should be attempted. Otherwise it will default.</p>
+<p>Interval gives an lower bound for how often the automation
+run should be attempted.</p>
 </td>
 </tr>
 <tr>
@@ -302,6 +313,19 @@ CommitSpec
 </td>
 <td>
 <p>Commit specifies how to commit to the git repo</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>suspend</code><br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Suspend tells the controller to not run this automation, until
+it is unset (or set to false). Defaults to false.</p>
 </td>
 </tr>
 </tbody>
@@ -363,6 +387,21 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>ReconcileRequestStatus</code><br>
+<em>
+<a href="https://godoc.org/github.com/fluxcd/pkg/apis/meta#ReconcileRequestStatus">
+github.com/fluxcd/pkg/apis/meta.ReconcileRequestStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ReconcileRequestStatus</code> are embedded into this type.)
+</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Changes the field `RunInterval` (used to be MinimumRunInterval`) to just `Interval`, and makes it required rather than optional, since its meaning more or less lines up with what the other GitOps toolkit API types use.

Also, since I'm here, provide a constant for the name of the kind.

Fixes #61.
