### PR TITLE
Make the branch field mandatory

### DIFF
--- a/api/v1alpha1/imageupdateautomation_types.go
+++ b/api/v1alpha1/imageupdateautomation_types.go
@@ -54,11 +54,9 @@ type GitCheckoutSpec struct {
 	// to a git repository to update files in.
 	// +required
 	GitRepositoryRef corev1.LocalObjectReference `json:"gitRepositoryRef"`
-	// Branch gives the branch to clone from the git repository. If
-	// missing, it will be left to default; be aware this may give
-	// indeterminate results.
-	// +optional
-	Branch string `json:"branch,omitempty"`
+	// Branch gives the branch to clone from the git repository.
+	// +required
+	Branch string `json:"branch"`
 }
 
 // UpdateStrategy is a union of the various strategies for updating

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -47,8 +47,6 @@ spec:
                 properties:
                   branch:
                     description: Branch gives the branch to clone from the git repository.
-                      If missing, it will be left to default; be aware this may give
-                      indeterminate results.
                     type: string
                   gitRepositoryRef:
                     description: GitRepositoryRef refers to the resource giving access
@@ -60,6 +58,7 @@ spec:
                         type: string
                     type: object
                 required:
+                - branch
                 - gitRepositoryRef
                 type: object
               commit:


### PR DESCRIPTION
Instead of having an arbitrary default branch, make the checkout
branch mandatory. This needed a little finessing in the tests, since
they did not cover using different branches (though did cover using a
non-standard branch).
