### PR TITLE
Update Alpine to v3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=1 go build -o image-automation-controller main.go
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL org.opencontainers.image.source="https://github.com/fluxcd/image-automation-controller"
 
@@ -45,7 +45,7 @@ COPY --from=builder /workspace/image-automation-controller /usr/local/bin/
 # https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
 RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 
-RUN addgroup -S controller && adduser -S -g controller controller
+RUN addgroup -S controller && adduser -S controller -G controller
 
 USER controller
 

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         prometheus.io/port: "8080"
     spec:
       terminationGracePeriodSeconds: 10
+      # Required for AWS IAM Role bindings
+      # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
+      securityContext:
+        fsGroup: 1337
       containers:
       - name: manager
         image: fluxcd/image-automation-controller


### PR DESCRIPTION
Changes:
- set fsGroup to allow AWS IAM Role bindings (ref: https://github.com/fluxcd/source-controller/issues/284)
- fix the group assignment in Alpine
- bump Alpine to 3.13
