### PR TITLE
Better error messages from `git push`

### DIFF
--- a/controllers/git_error_test.go
+++ b/controllers/git_error_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2020, 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLibgit2ErrorTidy(t *testing.T) {
+	// this is what GitLab sends if the deploy key doesn't have write access
+	gitlabMessage := `remote: 
+remote: ========================================================================
+remote: 
+remote: This deploy key does not have write access to this project.
+remote: 
+remote: ========================================================================
+remote: 
+`
+	expectedReformat := "remote: This deploy key does not have write access to this project."
+
+	err := errors.New(gitlabMessage)
+	err = libgit2PushError(err)
+	reformattedMessage := err.Error()
+	if reformattedMessage != expectedReformat {
+		t.Errorf("expected %q, got %q", expectedReformat, reformattedMessage)
+	}
+}
+
+func TestLibgit2Multiline(t *testing.T) {
+	// this is a hypothetical error message, in which the useful
+	// content spans more than one line
+	multilineMessage := `remote: 
+remote: ========================================================================
+remote: 
+remote: This deploy key does not have write access to this project.
+remote: You will need to create a new deploy key.
+remote: 
+remote: ========================================================================
+remote: 
+`
+	expectedReformat := "remote: This deploy key does not have write access to this project. You will need to create a new deploy key."
+
+	err := errors.New(multilineMessage)
+	err = libgit2PushError(err)
+	reformattedMessage := err.Error()
+	if reformattedMessage != expectedReformat {
+		t.Errorf("expected %q, got %q", expectedReformat, reformattedMessage)
+	}
+}
+
+func TestLibgit2ErrorUnchanged(t *testing.T) {
+	// this is (roughly) what GitHub sends if the deploy key doesn't have write access
+	regularMessage := `remote: ERROR: deploy key does not have permissions`
+	expectedReformat := regularMessage
+	err := errors.New(regularMessage)
+	err = libgit2PushError(err)
+	reformattedMessage := err.Error()
+	if reformattedMessage != expectedReformat {
+		t.Errorf("expected %q, got %q", expectedReformat, reformattedMessage)
+	}
+}
+
+func TestGoGitErrorReplace(t *testing.T) {
+	// this is what go-git uses as the error message is if the remote
+	// sends a blank first line
+	unknownMessage := `unknown error: remote: `
+	err := errors.New(unknownMessage)
+	err = gogitPushError(err)
+	reformattedMessage := err.Error()
+	if reformattedMessage == unknownMessage {
+		t.Errorf("expected rewritten error, got %q", reformattedMessage)
+	}
+}
+
+func TestGoGitErrorUnchanged(t *testing.T) {
+	// this is (roughly) what GitHub sends if the deploy key doesn't
+	// have write access; go-git passes this on verbatim
+	regularMessage := `remote: ERROR: deploy key does not have write access`
+	expectedReformat := regularMessage
+	err := errors.New(regularMessage)
+	err = gogitPushError(err)
+	reformattedMessage := err.Error()
+	// test that it's been rewritten, without checking the exact content
+	if len(reformattedMessage) > len(expectedReformat) {
+		t.Errorf("expected %q, got %q", expectedReformat, reformattedMessage)
+	}
+}


### PR DESCRIPTION
libgit2 and go-git both have flaws in the way they treat errors from the remote. go-git takes only the first line, meaning that it gets a blank error message from GitLab which like to respond with a banner. libgit2 returns the whole response, including blank lines and fences ("=========...").

This commit corrects for both these flaws, by supplying a message if go-git has taken a blank line, and stripping out blank lines and fences from libgit2's error. This is unavoidably a brittle approach, so I have limited it to just the situation that was reported as a problem: pushing to the upstream git repo.

Fixes #102.