### PR TITLE
Supply update result value to the commit message template

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -69,7 +69,9 @@ const defaultMessageTemplate = `Update from image update automation`
 const repoRefKey = ".spec.gitRepository"
 const imagePolicyKey = ".spec.update.imagePolicy"
 
-type TemplateValues struct {
+// TemplateData is the type of the value given to the commit message
+// template.
+type TemplateData struct {
 	AutomationObject types.NamespacedName
 	Updated          update.Result
 }
@@ -90,7 +92,7 @@ type ImageUpdateAutomationReconciler struct {
 func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	now := time.Now()
-	var templateValues TemplateValues
+	var templateValues TemplateData
 
 	var auto imagev1.ImageUpdateAutomation
 	if err := r.Get(ctx, req.NamespacedName, &auto); err != nil {
@@ -358,7 +360,7 @@ func cloneInto(ctx context.Context, access repoAccess, branch, path, impl string
 
 var errNoChanges error = errors.New("no changes made to working directory")
 
-func commitAll(ctx context.Context, repo *gogit.Repository, commit *imagev1.CommitSpec, values TemplateValues) (string, error) {
+func commitAll(ctx context.Context, repo *gogit.Repository, commit *imagev1.CommitSpec, values TemplateData) (string, error) {
 	working, err := repo.Worktree()
 	if err != nil {
 		return "", err

--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -69,6 +69,11 @@ const defaultMessageTemplate = `Update from image update automation`
 const repoRefKey = ".spec.gitRepository"
 const imagePolicyKey = ".spec.update.imagePolicy"
 
+type TemplateValues struct {
+	AutomationObject types.NamespacedName
+	Updated          update.Result
+}
+
 // ImageUpdateAutomationReconciler reconciles a ImageUpdateAutomation object
 type ImageUpdateAutomationReconciler struct {
 	client.Client
@@ -85,6 +90,7 @@ type ImageUpdateAutomationReconciler struct {
 func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logr.FromContext(ctx)
 	now := time.Now()
+	var templateValues TemplateValues
 
 	var auto imagev1.ImageUpdateAutomation
 	if err := r.Get(ctx, req.NamespacedName, &auto); err != nil {
@@ -95,6 +101,8 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 		log.Info("ImageUpdateAutomation is suspended, skipping automation run")
 		return ctrl.Result{}, nil
 	}
+
+	templateValues.AutomationObject = req.NamespacedName
 
 	// Record readiness metric when exiting; if there's any points at
 	// which the readiness is updated _without also exiting_, they
@@ -178,8 +186,10 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 			return failWithError(err)
 		}
 
-		if _, err := updateAccordingToSetters(ctx, tmp, policies.Items); err != nil {
+		if result, err := updateAccordingToSetters(ctx, tmp, policies.Items); err != nil {
 			return failWithError(err)
+		} else {
+			templateValues.Updated = result
 		}
 	default:
 		log.Info("no update strategy given in the spec")
@@ -197,7 +207,7 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 	// The status message depends on what happens next. Since there's
 	// more than one way to succeed, there's some if..else below, and
 	// early returns only on failure.
-	if rev, err := commitAll(ctx, repo, &auto.Spec.Commit); err != nil {
+	if rev, err := commitAll(ctx, repo, &auto.Spec.Commit, templateValues); err != nil {
 		if err == errNoChanges {
 			r.event(ctx, auto, events.EventSeverityInfo, "no updates made")
 			log.V(debug).Info("no changes made in working directory; no commit")
@@ -348,7 +358,7 @@ func cloneInto(ctx context.Context, access repoAccess, branch, path, impl string
 
 var errNoChanges error = errors.New("no changes made to working directory")
 
-func commitAll(ctx context.Context, repo *gogit.Repository, commit *imagev1.CommitSpec) (string, error) {
+func commitAll(ctx context.Context, repo *gogit.Repository, commit *imagev1.CommitSpec, values TemplateValues) (string, error) {
 	working, err := repo.Worktree()
 	if err != nil {
 		return "", err
@@ -370,7 +380,7 @@ func commitAll(ctx context.Context, repo *gogit.Repository, commit *imagev1.Comm
 		return "", err
 	}
 	buf := &strings.Builder{}
-	if err := tmpl.Execute(buf, "no data! yet"); err != nil {
+	if err := tmpl.Execute(buf, values); err != nil {
 		return "", err
 	}
 

--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -178,7 +178,7 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 			return failWithError(err)
 		}
 
-		if err := updateAccordingToSetters(ctx, tmp, policies.Items); err != nil {
+		if _, err := updateAccordingToSetters(ctx, tmp, policies.Items); err != nil {
 			return failWithError(err)
 		}
 	default:
@@ -523,6 +523,6 @@ func (r *ImageUpdateAutomationReconciler) recordReadinessMetric(ctx context.Cont
 
 // updateAccordingToSetters updates files under the root by treating
 // the given image policies as kyaml setters.
-func updateAccordingToSetters(ctx context.Context, path string, policies []imagev1_reflect.ImagePolicy) error {
+func updateAccordingToSetters(ctx context.Context, path string, policies []imagev1_reflect.ImagePolicy) (update.Result, error) {
 	return update.UpdateWithSetters(path, path, policies)
 }

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -135,7 +135,7 @@ Objects:
 
 Images:
 {{ range .Updated.Images -}}
-- {{.}}
+- {{.}} ({{.Policy.Name}})
 {{ end -}}
 `
 			commitMessageFmt = `Commit summary
@@ -147,13 +147,11 @@ Files:
 Objects:
 - Deployment test
 Images:
-- helloworld:v1.0.0
+- helloworld:v1.0.0 (%s)
 `
 		)
 
 		BeforeEach(func() {
-			commitMessage = fmt.Sprintf(commitMessageFmt, namespace.Name)
-
 			Expect(initGitRepo(gitServer, "testdata/appconfig", branch, repositoryPath)).To(Succeed())
 			repoURL := gitServer.HTTPAddressWithCredentials() + repositoryPath
 			var err error
@@ -206,6 +204,9 @@ Images:
 			}
 			Expect(k8sClient.Create(context.Background(), policy)).To(Succeed())
 			Expect(k8sClient.Status().Update(context.Background(), policy)).To(Succeed())
+
+			// Format the expected message given the generated values
+			commitMessage = fmt.Sprintf(commitMessageFmt, namespace.Name, policyKey.Name)
 
 			// Insert a setter reference into the deployment file,
 			// before creating the automation object itself.

--- a/docs/spec/v1alpha1/imageupdateautomations.md
+++ b/docs/spec/v1alpha1/imageupdateautomations.md
@@ -143,9 +143,9 @@ spec:
 
 will result in commits with the author `Fluxbot <flux@example.com>`.
 
-The `messageTemplate` field is a string which will be used as the commit message. If empty, there is
-a default message; but you will likely want to provide your own, especially if you want to put
-tokens in to control how CI reacts to commits made by automation. For example,
+The `messageTemplate` field is a string which will be used as a template for the commit message. If
+empty, there is a default message; but you will likely want to provide your own, especially if you
+want to put tokens in to control how CI reacts to commits made by automation. For example,
 
 ```yaml
 spec:
@@ -158,7 +158,8 @@ spec:
 
 ### Commit template data
 
-The data available to the commit message template have this structure (not reproduced verbatim):
+The message template is a [Go text template][go-text-template]. The data available to the template
+have this structure (not reproduced verbatim):
 
 ```go
 // controllers/imageupdateautomation_controller.go
@@ -231,27 +232,28 @@ func (r Result) Objects() map[ObjectIdentifier][]ImageRef {
 The methods let you range over the objects and images without descending the data structure. Here's
 an example of using the fields and methods in a template:
 
-```go
-commitTemplate := `
-`Automated image update
-
-Automation name: {{ .AutomationObject }}
-
-Files:
-{{ range $filename, $_ := .Updated.Files -}}
-- {{ $filename }}
-{{ end -}}
-
-Objects:
-{{ range $resource, $_ := .Updated.Objects -}}
-- {{ $resource.Kind }} {{ $resource.Name }}
-{{ end -}}
-
-Images:
-{{ range .Updated.Images -}}
-- {{.}}
-{{ end -}}
-`
+```yaml
+spec:
+  commit:
+    messsageTemplate: |
+      Automated image update
+      
+      Automation name: {{ .AutomationObject }}
+      
+      Files:
+      {{ range $filename, $_ := .Updated.Files -}}
+      - {{ $filename }}
+      {{ end -}}
+      
+      Objects:
+      {{ range $resource, $_ := .Updated.Objects -}}
+      - {{ $resource.Kind }} {{ $resource.Name }}
+      {{ end -}}
+      
+      Images:
+      {{ range .Updated.Images -}}
+      - {{.}}
+      {{ end -}}
 ```
 
 ## Status
@@ -295,3 +297,4 @@ resulted in a commit.
 [git-repo-ref]: https://toolkit.fluxcd.io/components/source/gitrepositories/
 [durations]: https://godoc.org/time#ParseDuration
 [source-docs]: https://toolkit.fluxcd.io/components/source/gitrepositories/#git-implementation
+[go-text-template]: https://golang.org/pkg/text/template/

--- a/pkg/update/result.go
+++ b/pkg/update/result.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"github.com/google/go-containerregistry/pkg/name"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -22,10 +23,20 @@ type ImageRef interface {
 	// Name gives the fully-qualified reference name, e.g.,
 	// "index.docker.io/library/helloworld:v1.0.1"
 	Name() string
+	// Policy gives the namespaced name of the image policy that led
+	// to the update.
+	Policy() types.NamespacedName
 }
 
 type imageRef struct {
 	name.Reference
+	policy types.NamespacedName
+}
+
+// Policy gives the namespaced name of the policy that led to the
+// update.
+func (i imageRef) Policy() types.NamespacedName {
+	return i.policy
 }
 
 // Repository gives the repository component of the image ref.

--- a/pkg/update/result.go
+++ b/pkg/update/result.go
@@ -16,3 +16,33 @@ type Result struct {
 type FileResult struct {
 	Objects map[yaml.ResourceIdentifier][]name.Reference
 }
+
+// Images returns all the images that were involved in at least one
+// update.
+func (r Result) Images() []name.Reference {
+	seen := make(map[name.Reference]struct{})
+	var result []name.Reference
+	for _, file := range r.Files {
+		for _, images := range file.Objects {
+			for _, ref := range images {
+				if _, ok := seen[ref]; !ok {
+					seen[ref] = struct{}{}
+					result = append(result, ref)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// Objects returns a map of all the objects against the images updated
+// within, regardless of which file they appear in.
+func (r Result) Objects() map[yaml.ResourceIdentifier][]name.Reference {
+	result := make(map[yaml.ResourceIdentifier][]name.Reference)
+	for _, file := range r.Files {
+		for res, refs := range file.Objects {
+			result[res] = append(result[res], refs...)
+		}
+	}
+	return result
+}

--- a/pkg/update/result.go
+++ b/pkg/update/result.go
@@ -1,0 +1,18 @@
+package update
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// Result reports the outcome of an update. It has a
+// file->objects->images structure, i.e., from the top level down to the
+// most detail. Different projections (e.g., all the images) are
+// available via the methods.
+type Result struct {
+	Files map[string]FileResult
+}
+
+type FileResult struct {
+	Objects map[yaml.ResourceIdentifier][]name.Reference
+}

--- a/pkg/update/result.go
+++ b/pkg/update/result.go
@@ -5,23 +5,62 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// Result reports the outcome of an update. It has a
-// file->objects->images structure, i.e., from the top level down to the
-// most detail. Different projections (e.g., all the images) are
-// available via the methods.
+// ImageRef represents the image reference used to replace a field
+// value in an update.
+type ImageRef interface {
+	// String returns a string representation of the image ref as it
+	// is used in the update; e.g., "helloworld:v1.0.1"
+	String() string
+	// Identifier returns the tag or digest; e.g., "v1.0.1"
+	Identifier() string
+	// Repository returns the repository component of the ImageRef,
+	// with an implied defaults, e.g., "library/helloworld"
+	Repository() string
+	// Registry returns the registry component of the ImageRef, e.g.,
+	// "index.docker.io"
+	Registry() string
+	// Name gives the fully-qualified reference name, e.g.,
+	// "index.docker.io/library/helloworld:v1.0.1"
+	Name() string
+}
+
+type imageRef struct {
+	name.Reference
+}
+
+// Repository gives the repository component of the image ref.
+func (i imageRef) Repository() string {
+	return i.Context().RepositoryStr()
+}
+
+// Registry gives the registry component of the image ref.
+func (i imageRef) Registry() string {
+	return i.Context().Registry.String()
+}
+
+// ObjectIdentifier holds the identifying data for a particular
+// object. This won't always have a name (e.g., a kustomization.yaml).
+type ObjectIdentifier struct {
+	yaml.ResourceIdentifier
+}
+
+// Result reports the outcome of an automated update. It has a nested
+// structure file->objects->images. Different projections (e.g., all
+// the images, regardless of object) are available via methods.
 type Result struct {
 	Files map[string]FileResult
 }
 
+// FileResult gives the updates in a particular file.
 type FileResult struct {
-	Objects map[yaml.ResourceIdentifier][]name.Reference
+	Objects map[ObjectIdentifier][]ImageRef
 }
 
 // Images returns all the images that were involved in at least one
 // update.
-func (r Result) Images() []name.Reference {
-	seen := make(map[name.Reference]struct{})
-	var result []name.Reference
+func (r Result) Images() []ImageRef {
+	seen := make(map[ImageRef]struct{})
+	var result []ImageRef
 	for _, file := range r.Files {
 		for _, images := range file.Objects {
 			for _, ref := range images {
@@ -37,8 +76,8 @@ func (r Result) Images() []name.Reference {
 
 // Objects returns a map of all the objects against the images updated
 // within, regardless of which file they appear in.
-func (r Result) Objects() map[yaml.ResourceIdentifier][]name.Reference {
-	result := make(map[yaml.ResourceIdentifier][]name.Reference)
+func (r Result) Objects() map[ObjectIdentifier][]ImageRef {
+	result := make(map[ObjectIdentifier][]ImageRef)
 	for _, file := range r.Files {
 		for res, refs := range file.Objects {
 			result[res] = append(result[res], refs...)

--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -4,15 +4,18 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+// mustRef creates an imageRef for use in tests. It panics if the ref
+// given is invalid.
 func mustRef(ref string) imageRef {
 	r, err := name.ParseReference(ref)
 	if err != nil {
 		panic(err)
 	}
-	return imageRef{r}
+	return imageRef{r, types.NamespacedName{}}
 }
 
 var _ = Describe("image ref", func() {

--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -1,0 +1,72 @@
+package update
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func mustRef(ref string) name.Reference {
+	r, err := name.ParseReference(ref)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+var _ = Describe("update results", func() {
+
+	var result Result
+	objectNames := []yaml.ResourceIdentifier{
+		yaml.ResourceIdentifier{
+			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "foo"},
+		},
+		yaml.ResourceIdentifier{
+			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "bar"},
+		},
+	}
+
+	BeforeEach(func() {
+		result = Result{
+			Files: map[string]FileResult{
+				"foo.yaml": {
+					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+						objectNames[0]: {
+							mustRef("image:v1.0"),
+							mustRef("other:v2.0"),
+						},
+					},
+				},
+				"bar.yaml": {
+					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+						objectNames[1]: {
+							mustRef("image:v1.0"),
+							mustRef("other:v2.0"),
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("deduplicates images", func() {
+		Expect(result.Images()).To(Equal([]name.Reference{
+			mustRef("image:v1.0"),
+			mustRef("other:v2.0"),
+		}))
+	})
+
+	It("collects images by object", func() {
+		Expect(result.Objects()).To(Equal(map[yaml.ResourceIdentifier][]name.Reference{
+			objectNames[0]: {
+				mustRef("image:v1.0"),
+				mustRef("other:v2.0"),
+			},
+			objectNames[1]: {
+				mustRef("image:v1.0"),
+				mustRef("other:v2.0"),
+			},
+		}))
+	})
+})

--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -7,31 +7,52 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-func mustRef(ref string) name.Reference {
+func mustRef(ref string) imageRef {
 	r, err := name.ParseReference(ref)
 	if err != nil {
 		panic(err)
 	}
-	return r
+	return imageRef{r}
 }
+
+var _ = Describe("image ref", func() {
+	It("gives each component of an image ref", func() {
+		ref := mustRef("helloworld:v1.0.1")
+		Expect(ref.String()).To(Equal("helloworld:v1.0.1"))
+		Expect(ref.Identifier()).To(Equal("v1.0.1"))
+		Expect(ref.Repository()).To(Equal("library/helloworld"))
+		Expect(ref.Registry()).To(Equal("index.docker.io"))
+		Expect(ref.Name()).To(Equal("index.docker.io/library/helloworld:v1.0.1"))
+	})
+
+	It("deals with hostnames and digests", func() {
+		image := "localhost:5000/org/helloworld@sha256:6745aaad46d795c9836632e1fb62f24b7e7f4c843144da8e47a5465c411a14be"
+		ref := mustRef(image)
+		Expect(ref.String()).To(Equal(image))
+		Expect(ref.Identifier()).To(Equal("sha256:6745aaad46d795c9836632e1fb62f24b7e7f4c843144da8e47a5465c411a14be"))
+		Expect(ref.Repository()).To(Equal("org/helloworld"))
+		Expect(ref.Registry()).To(Equal("localhost:5000"))
+		Expect(ref.Name()).To(Equal(image))
+	})
+})
 
 var _ = Describe("update results", func() {
 
 	var result Result
-	objectNames := []yaml.ResourceIdentifier{
-		yaml.ResourceIdentifier{
+	objectNames := []ObjectIdentifier{
+		ObjectIdentifier{yaml.ResourceIdentifier{
 			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "foo"},
-		},
-		yaml.ResourceIdentifier{
+		}},
+		ObjectIdentifier{yaml.ResourceIdentifier{
 			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "bar"},
-		},
+		}},
 	}
 
 	BeforeEach(func() {
 		result = Result{
 			Files: map[string]FileResult{
 				"foo.yaml": {
-					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+					Objects: map[ObjectIdentifier][]ImageRef{
 						objectNames[0]: {
 							mustRef("image:v1.0"),
 							mustRef("other:v2.0"),
@@ -39,7 +60,7 @@ var _ = Describe("update results", func() {
 					},
 				},
 				"bar.yaml": {
-					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+					Objects: map[ObjectIdentifier][]ImageRef{
 						objectNames[1]: {
 							mustRef("image:v1.0"),
 							mustRef("other:v2.0"),
@@ -51,14 +72,14 @@ var _ = Describe("update results", func() {
 	})
 
 	It("deduplicates images", func() {
-		Expect(result.Images()).To(Equal([]name.Reference{
+		Expect(result.Images()).To(Equal([]ImageRef{
 			mustRef("image:v1.0"),
 			mustRef("other:v2.0"),
 		}))
 	})
 
 	It("collects images by object", func() {
-		Expect(result.Objects()).To(Equal(map[yaml.ResourceIdentifier][]name.Reference{
+		Expect(result.Objects()).To(Equal(map[ObjectIdentifier][]ImageRef{
 			objectNames[0]: {
 				mustRef("image:v1.0"),
 				mustRef("other:v2.0"),

--- a/pkg/update/setters.go
+++ b/pkg/update/setters.go
@@ -190,7 +190,7 @@ updates:
 		file, ok := result.Files[update.file]
 		if !ok {
 			file = FileResult{
-				Objects: make(map[yaml.ResourceIdentifier][]name.Reference),
+				Objects: make(map[ObjectIdentifier][]ImageRef),
 			}
 			result.Files[update.file] = file
 		}
@@ -200,18 +200,20 @@ updates:
 		if err != nil {
 			continue updates
 		}
-		id := meta.GetIdentifier()
+		id := ObjectIdentifier{meta.GetIdentifier()}
+
 		name, ok := nameToImage[update.name]
 		if !ok { // this means an update was made that wasn't recorded as being an image
 			continue updates
 		}
 		// if the name and tag of an image are both used, we don't need to record it twice
+		ref := imageRef{name}
 		for _, n := range objects[id] {
-			if n == name {
+			if n == ref {
 				continue updates
 			}
 		}
-		objects[id] = append(objects[id], name)
+		objects[id] = append(objects[id], ref)
 	}
 	return result
 }

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -79,13 +79,13 @@ var _ = Describe("Update image via kyaml setters2", func() {
 		result, err := UpdateWithSetters("testdata/setters/original", tmp, policies)
 		Expect(err).ToNot(HaveOccurred())
 
-		kustomizeResourceID := yaml.ResourceIdentifier{
+		kustomizeResourceID := ObjectIdentifier{yaml.ResourceIdentifier{
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: "kustomize.config.k8s.io/v1beta1",
 				Kind:       "Kustomization",
 			},
-		}
-		markedResourceID := yaml.ResourceIdentifier{
+		}}
+		markedResourceID := ObjectIdentifier{yaml.ResourceIdentifier{
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: "batch/v1beta1",
 				Kind:       "CronJob",
@@ -94,20 +94,21 @@ var _ = Describe("Update image via kyaml setters2", func() {
 				Namespace: "bar",
 				Name:      "foo",
 			},
-		}
-		expectedImageRef, _ := name.ParseReference("updated:v1.0.1")
+		}}
+		r, _ := name.ParseReference("updated:v1.0.1")
+		expectedImageRef := imageRef{r}
 
 		expectedResult := Result{
 			Files: map[string]FileResult{
 				"kustomization.yaml": {
-					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+					Objects: map[ObjectIdentifier][]ImageRef{
 						kustomizeResourceID: {
 							expectedImageRef,
 						},
 					},
 				},
 				"marked.yaml": {
-					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+					Objects: map[ObjectIdentifier][]ImageRef{
 						markedResourceID: {
 							expectedImageRef,
 						},

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/fluxcd/image-automation-controller/pkg/test"
@@ -96,7 +97,10 @@ var _ = Describe("Update image via kyaml setters2", func() {
 			},
 		}}
 		r, _ := name.ParseReference("updated:v1.0.1")
-		expectedImageRef := imageRef{r}
+		expectedImageRef := imageRef{r, types.NamespacedName{
+			Name:      "policy",
+			Namespace: "automation-ns",
+		}}
 
 		expectedResult := Result{
 			Files: map[string]FileResult{

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -21,9 +21,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/fluxcd/image-automation-controller/pkg/test"
 	imagev1alpha1_reflect "github.com/fluxcd/image-reflector-controller/api/v1alpha1"
@@ -52,7 +54,68 @@ var _ = Describe("Update image via kyaml setters2", func() {
 			},
 		}
 
-		Expect(UpdateWithSetters("testdata/setters/original", tmp, policies)).To(Succeed())
+		_, err = UpdateWithSetters("testdata/setters/original", tmp, policies)
+		Expect(err).ToNot(HaveOccurred())
 		test.ExpectMatchingDirectories(tmp, "testdata/setters/expected")
+	})
+
+	It("gives the result of the updates", func() {
+		tmp, err := ioutil.TempDir("", "gotest")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tmp)
+
+		policies := []imagev1alpha1_reflect.ImagePolicy{
+			imagev1alpha1_reflect.ImagePolicy{
+				ObjectMeta: metav1.ObjectMeta{ // name matches marker used in testdata/setters/{original,expected}
+					Namespace: "automation-ns",
+					Name:      "policy",
+				},
+				Status: imagev1alpha1_reflect.ImagePolicyStatus{
+					LatestImage: "updated:v1.0.1",
+				},
+			},
+		}
+
+		result, err := UpdateWithSetters("testdata/setters/original", tmp, policies)
+		Expect(err).ToNot(HaveOccurred())
+
+		kustomizeResourceID := yaml.ResourceIdentifier{
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: "kustomize.config.k8s.io/v1beta1",
+				Kind:       "Kustomization",
+			},
+		}
+		markedResourceID := yaml.ResourceIdentifier{
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: "batch/v1beta1",
+				Kind:       "CronJob",
+			},
+			NameMeta: yaml.NameMeta{
+				Namespace: "bar",
+				Name:      "foo",
+			},
+		}
+		expectedImageRef, _ := name.ParseReference("updated:v1.0.1")
+
+		expectedResult := Result{
+			Files: map[string]FileResult{
+				"kustomization.yaml": {
+					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+						kustomizeResourceID: {
+							expectedImageRef,
+						},
+					},
+				},
+				"marked.yaml": {
+					Objects: map[yaml.ResourceIdentifier][]name.Reference{
+						markedResourceID: {
+							expectedImageRef,
+						},
+					},
+				},
+			},
+		}
+
+		Expect(result).To(Equal(expectedResult))
 	})
 })


### PR DESCRIPTION
The effect of this PR is to give the commit message template some data to work with. Specifically: a data structure (definition given below) which holds the images updated for each object, for each file; and the name of the image automation object that created the commit.

This is the update result:

```go
type Result struct {
	Files map[string]FileResult
}

type FileResult struct {
	Objects map[yaml.ResourceIdentifier][]name.Reference
}
```

.. where the map keys are file paths and `{APIVersion, Kind, Name, Namespace}`, and `name.Reference` is an image name.

Here's a template that uses the result structure to print out what was updated, in different ways:

```go
template := `Commit summary

Image update automation object: {{ .AutomationObject }}

Files:
{{ range $filename, $_ := .Updated.Files -}}
- {{ $filename }}
{{ end -}}

Objects:
{{ range $resource, $_ := .Updated.Objects -}}
- {{ $resource.Kind }} {{ $resource.Name }}
{{ end -}}

Images:
{{ range .Updated.Images -}}
- {{.}}
{{ end -}}
`
```

(There are methods on the Result type to make enumerating the objects and image names possible without descending into the structure.)

EDIT While writing the guide I made the template data more convenient to use (see the commit):
 - [x] Write a reference for the template data
 - [x] Give the name of the policy for each update (A: yes it's useful)

EDIT Not sure whether these are worth it:
 - [?] Wrap ResourceIdentifier in something that has convenient string-returning methods
