### PR TITLE
Fix typo in template code example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ images that were updated along with the resource kind and name e.g.:
 ```yaml
 spec:
   commit:
-    messsageTemplate: |
+    messageTemplate: |
       Automated image update
       
       Automation name: {{ .AutomationObject }}

--- a/docs/spec/v1alpha1/imageupdateautomations.md
+++ b/docs/spec/v1alpha1/imageupdateautomations.md
@@ -161,7 +161,7 @@ want to put tokens in to control how CI reacts to commits made by automation. Fo
 ```yaml
 spec:
   commit:
-    messsageTemplate: |
+    messageTemplate: |
       Automated image update by Flux
       
       [ci skip]
@@ -246,7 +246,7 @@ an example of using the fields and methods in a template:
 ```yaml
 spec:
   commit:
-    messsageTemplate: |
+    messageTemplate: |
       Automated image update
       
       Automation name: {{ .AutomationObject }}


### PR DESCRIPTION
Fixes a minor typo that causes CRD violation if copy and pasted

```
error: error validating "./clusters/staging/flux-system/image-update-automation.yml": error validating data: ValidationError(ImageUpdateAutomation.spec.commit): unknown field "messsageTemplate" in io.fluxcd.toolkit.image.v1alpha1.ImageUpdateAutomation.spec.commit; if you choose to ignore these errors, turn validation off with --validate=false
```