### PR TITLE
Ensure that an unchanged image is not in update result

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1617,6 +1617,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQb
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/controller-runtime v0.8.3 h1:GMHvzjTmaWHQB8HadW+dIvBoJuLvZObYJ5YoZruPRao=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
+sigs.k8s.io/kustomize v1.0.11 h1:Yb+6DDt9+aR2AvQApvUaKS/ugteeG4MPyoFeUHiPOjk=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/kyaml v0.10.16 h1:4rn0PTEK4STOA5kbpz72oGskjpKYlmwru4YRgVQFv+c=

--- a/pkg/update/filter.go
+++ b/pkg/update/filter.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020, 2021 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package update
+
+import (
+	"github.com/go-openapi/spec"
+	"sigs.k8s.io/kustomize/kyaml/fieldmeta"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/kustomize/kyaml/setters2"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// The implementation of this filter is adapted from
+// [kyaml](https://github.com/kubernetes-sigs/kustomize/blob/kyaml/v0.10.16/kyaml/setters2/set.go),
+// with the following changes:
+//
+// - it records each field it sets
+//
+// - it will implicitly set all fields referring to a setter in the
+// schema -- this is a flag in the kyaml implementation, but the only
+// desired mode of operation here
+//
+// - substitutions are not supported -- they are not used for image
+// updates
+//
+// - no validation is done on the value being set -- since the schema
+// is constructed here, it's assumed the values will be appropriate
+//
+// - only scalar nodes are considered (i.e., no sequence replacements)
+//
+// - only per-field schema references (those in a comment in the YAML)
+// are considered -- these are the only ones relevant to image updates
+
+type SetAllAndRecord struct {
+	SettersSchema *spec.Schema
+	Record        func(setter, oldValue, newValue string)
+}
+
+func (s *SetAllAndRecord) Filter(object *yaml.RNode) (*yaml.RNode, error) {
+	return object, accept(s, object, "", s.SettersSchema)
+}
+
+// visitor is provided to accept to walk the AST.
+type visitor interface {
+	// visitScalar is called for each scalar field value on a resource
+	// node is the scalar field value
+	// path is the path to the field; path elements are separated by '.'
+	visitScalar(node *yaml.RNode, path string, schema *openapi.ResourceSchema) error
+}
+
+// getSchema returns per-field OpenAPI schema for a particular node.
+func getSchema(r *yaml.RNode, settersSchema *spec.Schema) *openapi.ResourceSchema {
+	// get the override schema if it exists on the field
+	fm := fieldmeta.FieldMeta{SettersSchema: settersSchema}
+	if err := fm.Read(r); err == nil && !fm.IsEmpty() {
+		// per-field schema, this is fine
+		if fm.Schema.Ref.String() != "" {
+			// resolve the reference
+			s, err := openapi.Resolve(&fm.Schema.Ref, settersSchema)
+			if err == nil && s != nil {
+				fm.Schema = *s
+			}
+		}
+		return &openapi.ResourceSchema{Schema: &fm.Schema}
+	}
+	return nil
+}
+
+// accept walks the AST and calls the visitor at each scalar node.
+func accept(v visitor, object *yaml.RNode, p string, settersSchema *spec.Schema) error {
+	switch object.YNode().Kind {
+	case yaml.DocumentNode:
+		// Traverse the child of the document
+		return accept(v, yaml.NewRNode(object.YNode()), p, settersSchema)
+	case yaml.MappingNode:
+		return object.VisitFields(func(node *yaml.MapNode) error {
+			// Traverse each field value
+			return accept(v, node.Value, p+"."+node.Key.YNode().Value, settersSchema)
+		})
+	case yaml.SequenceNode:
+		return object.VisitElements(func(node *yaml.RNode) error {
+			// Traverse each list element
+			return accept(v, node, p, settersSchema)
+		})
+	case yaml.ScalarNode:
+		fieldSchema := getSchema(object, settersSchema)
+		return v.visitScalar(object, p, fieldSchema)
+	}
+	return nil
+}
+
+// set applies the value from ext to field
+func (s *SetAllAndRecord) set(field *yaml.RNode, ext *setters2.CliExtension, sch *spec.Schema) (bool, error) {
+	// check full setter
+	if ext.Setter == nil {
+		return false, nil
+	}
+
+	// this has a full setter, set its value
+	old := field.YNode().Value
+	field.YNode().Value = ext.Setter.Value
+	s.Record(ext.Setter.Name, old, ext.Setter.Value)
+
+	// format the node so it is quoted if it is a string. If there is
+	// type information on the setter schema, we use it. Otherwise we
+	// fall back to the field schema if it exists.
+	if len(sch.Type) > 0 {
+		yaml.FormatNonStringStyle(field.YNode(), *sch)
+	}
+	return true, nil
+}
+
+// visitScalar
+func (s *SetAllAndRecord) visitScalar(object *yaml.RNode, p string, fieldSchema *openapi.ResourceSchema) error {
+	if fieldSchema == nil {
+		return nil
+	}
+	// get the openAPI for this field describing how to apply the setter
+	ext, err := setters2.GetExtFromSchema(fieldSchema.Schema)
+	if err != nil {
+		return err
+	}
+	if ext == nil {
+		return nil
+	}
+
+	// perform a direct set of the field if it matches
+	// %%% FIXME record it!
+	_, err = s.set(object, ext, fieldSchema.Schema)
+	return err
+}

--- a/pkg/update/testdata/setters/expected/marked.yaml
+++ b/pkg/update/testdata/setters/expected/marked.yaml
@@ -12,3 +12,5 @@ spec:
           containers:
           - name: c
             image: updated:v1.0.1 # {"$imagepolicy": "automation-ns:policy"}
+          - name: d
+            image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}

--- a/pkg/update/testdata/setters/original/marked.yaml
+++ b/pkg/update/testdata/setters/original/marked.yaml
@@ -12,3 +12,5 @@ spec:
           containers:
           - name: c
             image: image:v1.0.0 # {"$imagepolicy": "automation-ns:policy"}
+          - name: d
+            image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -38,6 +38,30 @@ func TestUpdate(t *testing.T) {
 }
 
 var _ = Describe("Update image via kyaml setters2", func() {
+
+	var (
+		policies = []imagev1alpha1_reflect.ImagePolicy{
+			imagev1alpha1_reflect.ImagePolicy{
+				ObjectMeta: metav1.ObjectMeta{ // name matches marker used in testdata/setters/{original,expected}
+					Namespace: "automation-ns",
+					Name:      "policy",
+				},
+				Status: imagev1alpha1_reflect.ImagePolicyStatus{
+					LatestImage: "updated:v1.0.1",
+				},
+			},
+			imagev1alpha1_reflect.ImagePolicy{
+				ObjectMeta: metav1.ObjectMeta{ // name matches marker used in testdata/setters/{original,expected}
+					Namespace: "automation-ns",
+					Name:      "unchanged",
+				},
+				Status: imagev1alpha1_reflect.ImagePolicyStatus{
+					LatestImage: "image:v1.0.0",
+				},
+			},
+		}
+	)
+
 	It("updates the image marked with the image policy (setter) ref", func() {
 		tmp, err := ioutil.TempDir("", "gotest")
 		Expect(err).ToNot(HaveOccurred())
@@ -53,6 +77,15 @@ var _ = Describe("Update image via kyaml setters2", func() {
 					LatestImage: "updated:v1.0.1",
 				},
 			},
+			imagev1alpha1_reflect.ImagePolicy{
+				ObjectMeta: metav1.ObjectMeta{ // name matches marker used in testdata/setters/{original,expected}
+					Namespace: "automation-ns",
+					Name:      "unchanged",
+				},
+				Status: imagev1alpha1_reflect.ImagePolicyStatus{
+					LatestImage: "image:v1.0.0",
+				},
+			},
 		}
 
 		_, err = UpdateWithSetters("testdata/setters/original", tmp, policies)
@@ -64,18 +97,6 @@ var _ = Describe("Update image via kyaml setters2", func() {
 		tmp, err := ioutil.TempDir("", "gotest")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(tmp)
-
-		policies := []imagev1alpha1_reflect.ImagePolicy{
-			imagev1alpha1_reflect.ImagePolicy{
-				ObjectMeta: metav1.ObjectMeta{ // name matches marker used in testdata/setters/{original,expected}
-					Namespace: "automation-ns",
-					Name:      "policy",
-				},
-				Status: imagev1alpha1_reflect.ImagePolicyStatus{
-					LatestImage: "updated:v1.0.1",
-				},
-			},
-		}
 
 		result, err := UpdateWithSetters("testdata/setters/original", tmp, policies)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
The first commit adapts the update->result test so that it checks an additional case: that a field with an update marker that _does_ correspond to a policy, but _doesn't_ get changed, is not included in the results.

The rest of the PR reimplements the setter filter, so that it will record exactly what changes are made. I have adapted it from kyaml, and stripped out a lot of generic code that is unnecessary here.

Fixes #133.