### PR TITLE
spec: formatting `v1alpha1` -> `v1alpha2` table

### DIFF
--- a/docs/spec/v1alpha2/imageupdateautomations.md
+++ b/docs/spec/v1alpha2/imageupdateautomations.md
@@ -427,8 +427,8 @@ differences, and where each `v1alpha1` field goes. A full example appears after 
 
 ### Moves and changes
 
-| v1alpha1 field | change in v1alpha2 |
-+----------------+--------------------+
+| `v1alpha1` field | change in `v1alpha2` |
+|------------------|----------------------|
 | .spec.checkout | moved to `.spec.git.checkout`, and optional |
 |                | `gitRepositoryRef` is now `.spec.sourceRef` |
 |                | `branch` is now `ref`, and optional         |


### PR DESCRIPTION
The previous format seems to have been a mixture of the format accepted
by most Markdown parsers, and the format Org Mode for Emacs likes.

Anyhow, we breathe Markdown.
