### PR TITLE
Update go-git to v5.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Version of the source-controller from which to get the GitRepository CRD.
 # Change this if you bump the source-controller/api version in go.mod.
-SOURCE_VER ?= v0.13.0
+SOURCE_VER ?= v0.13.2
 
 # Version of the image-reflector-controller from which to get the ImagePolicy CRD.
 # Change this if you bump the image-reflector-controller/api version in go.mod.

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/fluxcd/pkg/apis/meta v0.9.0
-	github.com/fluxcd/source-controller/api v0.13.0
+	github.com/fluxcd/source-controller/api v0.13.2
 	k8s.io/apimachinery v0.20.4
 	sigs.k8s.io/controller-runtime v0.8.3
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -90,8 +90,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fluxcd/pkg/apis/meta v0.9.0 h1:rxW69p+VmJCKXXkaRYnovRBFlKjd+MJQfm2RrB0B4j8=
 github.com/fluxcd/pkg/apis/meta v0.9.0/go.mod h1:yHuY8kyGHYz22I0jQzqMMGCcHViuzC/WPdo9Gisk8Po=
-github.com/fluxcd/source-controller/api v0.13.0 h1:p7SWHPpxco1EsGu2jnF0aCZcQcl4IYQzjcXf4K5GpcY=
-github.com/fluxcd/source-controller/api v0.13.0/go.mod h1:+EPyhxC7Y+hUnq7EwAkkLtfbwCxJxF5yfmiyzDk43KY=
+github.com/fluxcd/source-controller/api v0.13.2 h1:LdWeapRXal3FmxTKEMh6wshg7u8Z3V3IDiB8TOPwM9o=
+github.com/fluxcd/source-controller/api v0.13.2/go.mod h1:+EPyhxC7Y+hUnq7EwAkkLtfbwCxJxF5yfmiyzDk43KY=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,10 @@ require (
 	github.com/fluxcd/pkg/runtime v0.11.0
 	github.com/fluxcd/pkg/ssh v0.0.5
 	// If you bump this, change SOURCE_VER in the Makefile to match
-	github.com/fluxcd/source-controller v0.13.0
-	github.com/fluxcd/source-controller/api v0.13.0
+	github.com/fluxcd/source-controller v0.13.2
+	github.com/fluxcd/source-controller/api v0.13.2
 	github.com/go-git/go-billy/v5 v5.3.1
-	github.com/go-git/go-git/v5 v5.4.1
+	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v0.4.0
 	github.com/google/go-containerregistry v0.1.1
 	github.com/libgit2/git2go/v31 v31.4.14

--- a/go.sum
+++ b/go.sum
@@ -328,10 +328,10 @@ github.com/fluxcd/pkg/testserver v0.0.2/go.mod h1:pgUZTh9aQ44FSTQo+5NFlh7YMbUfdz
 github.com/fluxcd/pkg/untar v0.0.5/go.mod h1:O6V9+rtl8c1mHBafgqFlJN6zkF1HS5SSYn7RpQJ/nfw=
 github.com/fluxcd/pkg/version v0.0.1 h1:/8asQoDXSThz3csiwi4Qo8Zb6blAxLXbtxNgeMJ9bCg=
 github.com/fluxcd/pkg/version v0.0.1/go.mod h1:WAF4FEEA9xyhngF8TDxg3UPu5fA1qhEYV8Pmi2Il01Q=
-github.com/fluxcd/source-controller v0.13.0 h1:BhUZx+950S1b6+F+tN93sIPOgSJ+0mX8biKN2n313nA=
-github.com/fluxcd/source-controller v0.13.0/go.mod h1:8Y76JuS33R0RaMgIdZZfYVdVI2ZrrwmxyIyPbz4w09U=
-github.com/fluxcd/source-controller/api v0.13.0 h1:p7SWHPpxco1EsGu2jnF0aCZcQcl4IYQzjcXf4K5GpcY=
-github.com/fluxcd/source-controller/api v0.13.0/go.mod h1:+EPyhxC7Y+hUnq7EwAkkLtfbwCxJxF5yfmiyzDk43KY=
+github.com/fluxcd/source-controller v0.13.2 h1:l6GLeTPyawFgwWqa3J/U66Pc497zTNzs76kzzbqfOB0=
+github.com/fluxcd/source-controller v0.13.2/go.mod h1:kFpDEk18Esnp+FQz77niMMgAjH2jGPma/SLOCocMDk0=
+github.com/fluxcd/source-controller/api v0.13.2 h1:LdWeapRXal3FmxTKEMh6wshg7u8Z3V3IDiB8TOPwM9o=
+github.com/fluxcd/source-controller/api v0.13.2/go.mod h1:+EPyhxC7Y+hUnq7EwAkkLtfbwCxJxF5yfmiyzDk43KY=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -361,8 +361,8 @@ github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Ai
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=
 github.com/go-git/go-git-fixtures/v4 v4.2.1/go.mod h1:K8zd3kDUAykwTdDCr+I0per6Y6vMiRR/nnVTBtavnB0=
-github.com/go-git/go-git/v5 v5.4.1 h1:2RJXJuTMac944e419pJJJ3mOJBcr3A3M6SN6wQKZ/Gs=
-github.com/go-git/go-git/v5 v5.4.1/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
+github.com/go-git/go-git/v5 v5.4.2 h1:BXyZu9t0VkbiHtqrsvdq39UDhGJTl1h55VW6CSC4aY4=
+github.com/go-git/go-git/v5 v5.4.2/go.mod h1:gQ1kArt6d+n+BGd+/B/I74HwRTLhth2+zti4ihgckDc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=


### PR DESCRIPTION
This PR updates the source-controller packages to v0.13.2 bringing go-git to v5.4.2 that fixes #172 