### PR TITLE
Update go-yaml with changes to indentation style

### DIFF
--- a/controllers/testdata/appconfig-expected/deploy.yaml
+++ b/controllers/testdata/appconfig-expected/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-      - name: hello
-        image: helloworld:1.0.1 # SETTER_SITE
+        - name: hello
+          image: helloworld:1.0.1 # SETTER_SITE

--- a/controllers/testdata/appconfig-expected2/deploy.yaml
+++ b/controllers/testdata/appconfig-expected2/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-      - name: hello
-        image: helloworld:1.2.0 # SETTER_SITE
+        - name: hello
+          image: helloworld:1.2.0 # SETTER_SITE

--- a/controllers/testdata/appconfig-setters-expected/deploy.yaml
+++ b/controllers/testdata/appconfig-setters-expected/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-      - name: hello
-        image: helloworld:1.0.1 # SETTER_SITE
+        - name: hello
+          image: helloworld:1.0.1 # SETTER_SITE

--- a/go.mod
+++ b/go.mod
@@ -31,11 +31,8 @@ require (
 	k8s.io/client-go v0.20.4
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e
 	sigs.k8s.io/controller-runtime v0.8.3
-	sigs.k8s.io/kustomize/kyaml v0.10.19
+	sigs.k8s.io/kustomize/kyaml v0.10.21
 )
-
-// Force downgrade to version used by kyaml.
-replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 
 // side-effect of depending on source-controller
 // required by https://github.com/helm/helm/blob/v3.5.2/go.mod

--- a/go.sum
+++ b/go.sum
@@ -449,7 +449,6 @@ github.com/go-toolsmith/typep v1.0.2/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
 github.com/gobuffalo/envy v1.7.1/go.mod h1:FurDp9+EDPE4aIUS3ZLyD+7/9fpx7YRt/ukY6jIHf0w=
-github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8ze5s8JvPs=
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
@@ -717,7 +716,6 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
-github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
@@ -1523,8 +1521,9 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
@@ -1630,8 +1629,8 @@ sigs.k8s.io/controller-runtime v0.8.3 h1:GMHvzjTmaWHQB8HadW+dIvBoJuLvZObYJ5YoZru
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.10.19 h1:us4+KUSKRpSox16AmjHkYORIlkWuQSLUaU5iGL7kkK4=
-sigs.k8s.io/kustomize/kyaml v0.10.19/go.mod h1:h94DSoDbmnN4BTc6VTX7tGNGXZy29rbPo+R4jGMvA8U=
+sigs.k8s.io/kustomize/kyaml v0.10.21 h1:KdoEgz3HzmcaLUTFqs6aaqFpsaA9MVRIwOZbi8vMaD0=
+sigs.k8s.io/kustomize/kyaml v0.10.21/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06 h1:zD2IemQ4LmOcAumeiyDWXKUI2SO0NYDe3H6QGvPOVgU=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=

--- a/pkg/update/testdata/leave/expected/cronjob.yaml
+++ b/pkg/update/testdata/leave/expected/cronjob.yaml
@@ -10,5 +10,5 @@ spec:
       template:
         spec:
           containers:
-          - name: c
-            image: helloworld:v1.0.0
+            - name: c
+              image: helloworld:v1.0.0

--- a/pkg/update/testdata/leave/expected/deployment.yaml
+++ b/pkg/update/testdata/leave/expected/deployment.yaml
@@ -7,5 +7,8 @@ spec:
   template:
     spec:
       containers:
-      - name: c
-        image: helloworld:v1.0.0
+        - name: c
+          image: helloworld:v1.0.0
+          args:
+            # prove that go-yaml/yaml v3.0.0-20200615113413-eeeca48fe776 fixes https://github.com/kubernetes-sigs/kustomize/issues/3969
+            - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf

--- a/pkg/update/testdata/leave/original/deployment.yaml
+++ b/pkg/update/testdata/leave/original/deployment.yaml
@@ -9,3 +9,6 @@ spec:
       containers:
       - name: c
         image: helloworld:v1.0.0
+        args:
+          # prove that go-yaml/yaml v3.0.0-20200615113413-eeeca48fe776 fixes https://github.com/kubernetes-sigs/kustomize/issues/3969
+          - mv /etc/resolv.conf /etc/resolv.conf.OLD && ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf

--- a/pkg/update/testdata/replace/commented-expected/deployment.yaml
+++ b/pkg/update/testdata/replace/commented-expected/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: bar
 spec:
   template:
-    spec:
+    # prove that go-yaml/yaml v3.0.0-20200615113413-eeeca48fe776 fixes https://github.com/kubernetes-sigs/kustomize/issues/3605
+    # 컨테이너
+    spec: # 컨테이너
       containers:
-      - name: c
-        image: used:v1.1.0 # the comment must stay!
+        - name: c
+          image: used:v1.1.0 # the comment must stay!

--- a/pkg/update/testdata/replace/commented/deployment.yaml
+++ b/pkg/update/testdata/replace/commented/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: bar
 spec:
   template:
-    spec:
+    # prove that go-yaml/yaml v3.0.0-20200615113413-eeeca48fe776 fixes https://github.com/kubernetes-sigs/kustomize/issues/3605
+    # 컨테이너
+    spec: # 컨테이너
       containers:
       - name: c
         image: used:v1.0.0 # the comment must stay!

--- a/pkg/update/testdata/replace/expected/cronjob.yaml
+++ b/pkg/update/testdata/replace/expected/cronjob.yaml
@@ -10,5 +10,5 @@ spec:
       template:
         spec:
           containers:
-          - name: c
-            image: used:v1.1.0
+            - name: c
+              image: used:v1.1.0

--- a/pkg/update/testdata/replace/expected/deployment.yaml
+++ b/pkg/update/testdata/replace/expected/deployment.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-      - name: c
-        image: used:v1.1.0
+        - name: c
+          image: used:v1.1.0

--- a/pkg/update/testdata/setters/expected/kustomization.yaml
+++ b/pkg/update/testdata/setters/expected/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- unimportant.yaml
+  - unimportant.yaml
 images:
-- name: container
-  newName: index.repo.fake/updated # {"$imagepolicy": "automation-ns:policy:name"}
-  newTag: v1.0.1 # {"$imagepolicy": "automation-ns:policy:tag"}
+  - name: container
+    newName: index.repo.fake/updated # {"$imagepolicy": "automation-ns:policy:name"}
+    newTag: v1.0.1 # {"$imagepolicy": "automation-ns:policy:tag"}

--- a/pkg/update/testdata/setters/expected/marked.yaml
+++ b/pkg/update/testdata/setters/expected/marked.yaml
@@ -10,7 +10,7 @@ spec:
       template:
         spec:
           containers:
-          - name: c
-            image: index.repo.fake/updated:v1.0.1 # {"$imagepolicy": "automation-ns:policy"}
-          - name: d
-            image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}
+            - name: c
+              image: index.repo.fake/updated:v1.0.1 # {"$imagepolicy": "automation-ns:policy"}
+            - name: d
+              image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}


### PR DESCRIPTION
This PR updates the YAML packages (used by the controller to patch Kubernetes manifests) to fix long standing issues like panics that make the controller unusable for many users.

Dependencies changes:
- update `gopkg.in/yaml.v3` from  `v3.0.0-20200313102051-9f266ea9e77c` to `v3.0.0-20200615113413-eeeca48fe776` (fix: #140)
- update `sigs.k8s.io/kustomize/kyaml` from `v0.10.19` to `v0.10.21`

### Breaking change

The `gopkg.in/yaml.v3` update means that the indentation style changed:

From:

```yaml
spec:
  containers:
  - name: one
    image: image1:v1.0.0 # {"$imagepolicy": "automation-ns:policy1"}
  - name: two
    image: image2:v1.0.0 # {"$imagepolicy": "automation-ns:policy2"}
```

To:

```yaml
spec:
  containers:
    - name: one
      image: image1:v1.0.0 # {"$imagepolicy": "automation-ns:policy1"}
    - name: two
      image: image2:v1.0.0 # {"$imagepolicy": "automation-ns:policy2"}
```

While Kustomize kyaml is using an older version of go-yaml we can't hold onto this forever. I find it unacceptable for Flux to keep crashing due to bugs fixed upstream in go-yaml. Kustomize may chose to delay this update (see https://github.com/kubernetes-sigs/kustomize/pull/3789 and https://github.com/kubernetes-sigs/kustomize/issues/3946) but this doesn't mean we are obliged to do the same. The image automation is alpha and breaking changes like this are acceptable considering the tradeoffs. I hope at some point, go-yaml will be able to detect and preserve the original indentation but it seems unlikely https://github.com/go-yaml/yaml/issues/661#issuecomment-733677290

Closes #92