### PR TITLE
Use Debian as base image

### DIFF
--- a/.github/actions/run-tests/Dockerfile
+++ b/.github/actions/run-tests/Dockerfile
@@ -1,12 +1,17 @@
-FROM golang:1.16-alpine
+FROM golang:1.16-buster as builder
 
-# Add any build or testing essential system packages
-RUN apk add --no-cache build-base git pkgconf
-RUN apk add --no-cache libgit2-dev~=1.1
-RUN apk add --no-cache curl
+# Up-to-date libgit2 dependencies are only available in sid (unstable).
+RUN echo "deb http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list \
+    && echo "deb-src http://deb.debian.org/debian unstable main" >> /etc/apt/sources.list
+RUN set -eux; \
+    apt-get update \
+    && apt-get install -y libgit2-dev/unstable zlib1g-dev/unstable libssh2-1-dev/unstable libpcre3-dev/unstable \
+    && apt-get clean \
+    && apt-get autoremove --purge -y \
+    && rm -rf /var/lib/apt/lists/*
 
-# Use the GitHub Actions uid:gid combination for proper fs permissions
-RUN addgroup -g 116 -S test && adduser -u 1001 -S -g test test
+RUN groupadd -g 116 test && \
+    useradd -u 1001 --gid test --shell /bin/sh --create-home test
 
 # Run as test user
 USER test


### PR DESCRIPTION
This PR changes the base image for the test, build and controller container images to Debian slim.

Ref: https://github.com/fluxcd/source-controller/pull/391
Ref: https://github.com/fluxcd/source-controller/pull/386

Should fix but needs unit tests to prove it #186