### PR TITLE
More debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ endif
 
 TEST_CRDS:=controllers/testdata/crds
 
+# Log level for `make run`
+LOG_LEVEL?=info
+
 all: manager
 
 # Running the tests requires the source.toolkit.fluxcd.io CRDs
@@ -49,7 +52,7 @@ manager: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run ./main.go --log-level=${LOG_LEVEL} --log-encoding=console
 
 # Install CRDs into a cluster
 install: manifests

--- a/controllers/git_test.go
+++ b/controllers/git_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/go-logr/logr"
 )
 
 func populateRepoFromFixture(repo *git.Repository, fixture string) error {
@@ -100,7 +101,7 @@ func TestIgnoreBrokenSymlink(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = commitChangedManifests(repo, tmp, nil, nil, "unused")
+	_, err = commitChangedManifests(logr.Discard(), repo, tmp, nil, nil, "unused")
 	if err != errNoChanges {
 		t.Fatalf("expected no changes but got: %v", err)
 	}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -88,7 +89,7 @@ var _ = Describe("Update image via kyaml setters2", func() {
 			},
 		}
 
-		_, err = UpdateWithSetters("testdata/setters/original", tmp, policies)
+		_, err = UpdateWithSetters(logr.Discard(), "testdata/setters/original", tmp, policies)
 		Expect(err).ToNot(HaveOccurred())
 		test.ExpectMatchingDirectories(tmp, "testdata/setters/expected")
 	})
@@ -98,7 +99,7 @@ var _ = Describe("Update image via kyaml setters2", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(tmp)
 
-		result, err := UpdateWithSetters("testdata/setters/original", tmp, policies)
+		result, err := UpdateWithSetters(logr.Discard(), "testdata/setters/original", tmp, policies)
 		Expect(err).ToNot(HaveOccurred())
 
 		kustomizeResourceID := ObjectIdentifier{yaml.ResourceIdentifier{


### PR DESCRIPTION
This adds trace-level messages to the log, in particular for

 - which setters are created from policies, and which are invoked on the repo
 - which files are scanned as YAMLs
 - which files are added to the commit, and which are ignored
