### PR TITLE
feat: add controller concurrency

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func(done Done) {
 		Client: k8sManager.GetClient(),
 		Scheme: scheme.Scheme,
 	}
-	Expect(imageAutoReconciler.SetupWithManager(k8sManager)).To(Succeed())
+	Expect(imageAutoReconciler.SetupWithManager(k8sManager, ImageUpdateAutomationReconcilerOptions{})).To(Succeed())
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
The controller is now working with 4 concurrent workers by default.
This value is configurable through the `--concurrent` flag.

Signed-off-by: Max Jonas Werner <mail@makk.es>