### PR TITLE
Fix nil-dereference in controller

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -211,8 +211,8 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 		// Here's where it gets constrained. If there's no push branch
 		// given, then the checkout ref must include a branch, and
 		// that can be used.
-		if ref.Branch == "" {
-			failWithError(fmt.Errorf("Push branch not given explicitly, and cannot be inferred from .spec.git.checkout.ref or GitRepository .spec.ref"))
+		if ref == nil || ref.Branch == "" {
+			return failWithError(fmt.Errorf("Push branch not given explicitly, and cannot be inferred from .spec.git.checkout.ref or GitRepository .spec.ref"))
 		}
 		pushBranch = ref.Branch
 		tracelog.Info("using push branch from $ref.branch", "branch", pushBranch)


### PR DESCRIPTION
Fixes a nil-deref when the following conditions are all true:

- `gitSpec.Checkout` is nil
- `origin.Spec.Reference` is nil
- `gitSpec.push` is nil

Signed-off-by: David Korczynski <david@adalogics.com>