### PR TITLE
Release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.15.0
+
+**Release date:** 2021-10-08
+
+This prerelease improves the configuration of the `libgit2` C library, solving
+most issues around private key formats (e.g. PKCS#8 and ED25519) by ensuring
+it is linked against OpenSSL and LibSSH2.
+
+Improvements:
+* Update github.com/libgit2/git2go to v31.6.1
+  [#222](https://github.com/fluxcd/image-automation-controller/pull/222)
+* Use pkg/runtime consts for log levels
+  [#232](https://github.com/fluxcd/image-automation-controller/pull/232)
+* Update fluxcd/image-reflector-controller to v0.12.0
+  [#233](https://github.com/fluxcd/image-automation-controller/pull/233)
+
+Fixes:
+* Provide a sample of v1beta1 ImageUpdateAutomation
+  [#219](https://github.com/fluxcd/image-automation-controller/pull/219)
+* Fix nil-dereference in controller
+  [#224](https://github.com/fluxcd/image-automation-controller/pull/224)
+
 ## 0.14.1
 
 **Release date:** 2021-08-05

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: fluxcd/image-automation-controller
   newName: fluxcd/image-automation-controller
-  newTag: v0.14.1
+  newTag: v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/fluxcd/image-automation-controller/api => ./api
 require (
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7
 	github.com/cyphar/filepath-securejoin v0.2.2
-	github.com/fluxcd/image-automation-controller/api v0.14.1
+	github.com/fluxcd/image-automation-controller/api v0.15.0
 	// If you bump this, change REFLECTOR_VER in the Makefile to match
 	github.com/fluxcd/image-reflector-controller/api v0.12.0
 	github.com/fluxcd/pkg/apis/meta v0.10.1


### PR DESCRIPTION
This depends on #233 and an existing `api/v0.15.0` tag.