### PR TITLE
libgit2: free underlying C objects

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -636,10 +636,12 @@ func fetch(ctx context.Context, path string, branch string, access repoAccess) e
 	if err != nil {
 		return err
 	}
+	defer repo.Free()
 	origin, err := repo.Remotes.Lookup(originRemote)
 	if err != nil {
 		return err
 	}
+	defer origin.Free()
 	err = origin.Fetch(
 		[]string{refspec},
 		&libgit2.FetchOptions{
@@ -661,10 +663,12 @@ func push(ctx context.Context, path, branch string, access repoAccess) error {
 	if err != nil {
 		return err
 	}
+	defer repo.Free()
 	origin, err := repo.Remotes.Lookup(originRemote)
 	if err != nil {
 		return err
 	}
+	defer origin.Free()
 
 	callbacks := access.remoteCallbacks()
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fluxcd/pkg/runtime v0.12.1
 	github.com/fluxcd/pkg/ssh v0.1.0
 	// If you bump this, change SOURCE_VER in the Makefile to match
-	github.com/fluxcd/source-controller v0.16.0
+	github.com/fluxcd/source-controller v0.16.1-0.20211014172658-a62cfe828ae4
 	github.com/fluxcd/source-controller/api v0.16.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
@@ -33,7 +33,3 @@ require (
 	sigs.k8s.io/controller-runtime v0.9.5
 	sigs.k8s.io/kustomize/kyaml v0.10.21
 )
-
-// side-effect of depending on source-controller
-// required by https://github.com/helm/helm/blob/v3.6.0/go.mod
-replace github.com/docker/distribution => github.com/docker/distribution v0.0.0-20191216044856-a8371794149d

--- a/go.sum
+++ b/go.sum
@@ -296,7 +296,10 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v20.10.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.7+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
+github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.7+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
@@ -358,8 +361,8 @@ github.com/fluxcd/pkg/testserver v0.1.0/go.mod h1:fvt8BHhXw6c1+CLw1QFZxcQprlcXzs
 github.com/fluxcd/pkg/untar v0.1.0/go.mod h1:aGswNyzB1mlz/T/kpOS58mITBMxMKc9tlJBH037A2HY=
 github.com/fluxcd/pkg/version v0.1.0 h1:v+SmCanmCB5Tj2Cx9TXlj+kNRfPGbAvirkeqsp7ZEAQ=
 github.com/fluxcd/pkg/version v0.1.0/go.mod h1:V7Z/w8dxLQzv0FHqa5ox5TeyOd2zOd49EeuWFgnwyj4=
-github.com/fluxcd/source-controller v0.16.0 h1:GUzyh6+NmA8Tx9fhhz/shYo585ICM9lCG0gAWkr/kGA=
-github.com/fluxcd/source-controller v0.16.0/go.mod h1:WsrFDJcVFawfMvTuKaz52yU9NA+lxGy+6qRFO3tdbps=
+github.com/fluxcd/source-controller v0.16.1-0.20211014172658-a62cfe828ae4 h1:AHwi2sVULDTuuli9pp4TgL/j57XzA8kRz+8RYiBJan8=
+github.com/fluxcd/source-controller v0.16.1-0.20211014172658-a62cfe828ae4/go.mod h1:WsrFDJcVFawfMvTuKaz52yU9NA+lxGy+6qRFO3tdbps=
 github.com/fluxcd/source-controller/api v0.16.0 h1:xFz+K7lLg/82uOQp+a0g04GsgoWNfyzwXAoVQy4T/oI=
 github.com/fluxcd/source-controller/api v0.16.0/go.mod h1:guUCCapjzE2kocwFreQTM/IGvtAglIJc4L97mokairo=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=


### PR DESCRIPTION
Multi-arch image for testing: `docker.io/hiddeco/image-automation-controller:libgit2-free-64388a3@sha256:55a0b34ed8e7d1d27f1280c354b385ea2005c1ae82acb3402d880`

Depends on: https://github.com/fluxcd/source-controller/pull/452