### PR TITLE
Respect PKG_CONFIG_PATH from the environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,6 +27,40 @@ $ brew install cmake openssl@1.1 libssh2 pkg-config
 $ LIBGIT2_FORCE=1 make libgit2
 ```
 
+#### openssl and pkg-config
+
+You may see this message when trying to run a build:
+
+```
+# pkg-config --cflags  -- libgit2
+Package openssl was not found in the pkg-config search path.
+Perhaps you should add the directory containing `openssl.pc'
+to the PKG_CONFIG_PATH environment variable
+Package 'openssl', required by 'libgit2', not found
+pkg-config: exit status 1
+```
+
+On some macOS systems `brew` will not link the pkg-config file for
+openssl into expected directory, because it clashes with a
+system-provided openssl. When installing it, or if you do
+
+```console
+brew link openssl@1.1
+Warning: Refusing to link macOS provided/shadowed software: openssl@1.1
+If you need to have openssl@1.1 first in your PATH, run:
+  echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> ~/.profile
+
+For compilers to find openssl@1.1 you may need to set:
+  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+
+For pkg-config to find openssl@1.1 you may need to set:
+  export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+```
+
+.. it tells you (in the last part of the message) how to add `openssl`
+to your `PKG_CONFIG_PATH` so it can be found.
+
 ### Linux
 
 ```console

--- a/Makefile
+++ b/Makefile
@@ -89,14 +89,14 @@ ${CACHE}/imagepolicies_${REFLECTOR_VER}.yaml:
 
 test: $(LIBGIT2) test-api test_deps generate fmt vet manifests api-docs	## Run tests
 	LD_LIBRARY_PATH=$(LIBGIT2_LIB_PATH) \
-	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig/ \
+	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig/:$(PKG_CONFIG_PATH) \
 	go test ./... -coverprofile cover.out
 
 test-api:	## Run api tests
 	cd api; go test ./... -coverprofile cover.out
 
 manager: $(LIBGIT2) generate fmt vet	## Build manager binary
-	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig/ \
+	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig/:$(PKG_CONFIG_PATH) \
 	go build -o bin/manager main.go
 
 run: $(LIBGIT2) generate fmt vet manifests	# Run against the configured Kubernetes cluster in ~/.kube/config
@@ -133,7 +133,7 @@ fmt:	## Run go fmt against code
 	cd api; go fmt ./...
 
 vet: $(LIBGIT2)	## Run go vet against code
-	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig \
+	PKG_CONFIG_PATH=$(LIBGIT2_LIB_PATH)/pkgconfig:$(PKG_CONFIG_PATH) \
 	go vet ./...
 	cd api; go vet ./...
 


### PR DESCRIPTION
If brew (or some other installation method) has put openssl.pc in a non-traditional place, you need to add that place to `PKG_CONFIG_PATH`; but, the Makefile effectively resets it when calling anything that uses it.

So:
 - include any existing $PKG_CONFIG_PATH in invocations
 - document when and how to set PKG_CONFIG_PATH

---

Note: this doesn't appear to be necessary for source-controller. Hidde and I think this may be because git2go is a direct dependency there, whereas it's required via source-controller/pkg here -- why that matters is not clear :-/