### PR TITLE
config/crd: Update the generated CRD spec

### DIFF
--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -220,7 +220,6 @@ spec:
                         description: Reference gives a branch, tag or commit to clone from the Git repository.
                         properties:
                           branch:
-                            default: master
                             description: The Git branch to checkout, defaults to master.
                             type: string
                           commit:
@@ -427,7 +426,6 @@ spec:
                         description: Reference gives a branch, tag or commit to clone from the Git repository.
                         properties:
                           branch:
-                            default: master
                             description: The Git branch to checkout, defaults to master.
                             type: string
                           commit:


### PR DESCRIPTION
source-controller v0.17.0 updated the `GitRepositoryRef` definition which
updates `GitCheckoutSpec.Reference` in IAC APIs.