### PR TITLE
Replace strings.TrimRight with strings.TrimSuffix

### DIFF
--- a/pkg/update/setters.go
+++ b/pkg/update/setters.go
@@ -160,7 +160,7 @@ func UpdateWithSetters(tracelog logr.Logger, inpath, outpath string, policies []
 		// annoyingly, neither the library imported above, nor an
 		// alternative I found, will yield the original image name;
 		// this is an easy way to get it
-		name := strings.TrimRight(image, ":"+tag)
+		name := strings.TrimSuffix(image, ":"+tag)
 
 		imageSetter := fmt.Sprintf("%s:%s", policy.GetNamespace(), policy.GetName())
 		tracelog.Info("adding setter", "name", imageSetter)


### PR DESCRIPTION
TrimRight was not correctly used. It takes a set of characters as the
second argument and any chars matching the set on the right side of the
string would be trimmed. TrimSuffix does exactly what I originally
intended.

Fixes #261