### PR TITLE
Fix LIBGIT2_VERSION variable used in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SOURCE_VER ?= v0.17.0
 REFLECTOR_VER ?= v0.12.0
 
 # Version of libgit2 the controller should depend on.
-LIBGIT2_VER ?= 1.1.1
+LIBGIT2_VERSION ?= 1.1.1
 
 # Repository root based on Git metadata.
 REPOSITORY_ROOT := $(shell git rev-parse --show-toplevel)


### PR DESCRIPTION
libgit2 version is referred to as `LIBGIT2_VERSION` but the initial
default assignment is set to the variable `LIBGIT2_VER`, making
`$LIBGIT2_VERSION` unset.

### Background

The new libgit2 build was introduced in https://github.com/fluxcd/image-automation-controller/commit/370f98e2811861c127a5b1321ab311f5c8bad68b with `LIBGIT2_VER`
to store the default libgit2 version.
Changes in https://github.com/fluxcd/image-automation-controller/commit/a3e9f69bd58bdcf10a87bf0f7fd4a804364cf74d#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R42-R49 changed
the variable references to `LIBGIT2_VERSION`.