### PR TITLE
Fix LIBGIT2_VERSION variable used in Makefile [cherry-pick]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ SOURCE_VER ?= v0.16.0
 REFLECTOR_VER ?= v0.11.1
 
 # Version of libgit2 the controller should depend on.
-LIBGIT2_VER ?= 1.1.1
+LIBGIT2_VERSION ?= 1.1.1
 
 # Repository root based on Git metadata.
 REPOSITORY_ROOT := $(shell git rev-parse --show-toplevel)


### PR DESCRIPTION
libgit2 version is referred to as $LIBGIT2_VERSION but the initial
default assignment is set to the variable $LIBGIT2_VER, making
$LIBGIT2_VERSION unset.

:warning:  Cherry-pick of https://github.com/fluxcd/image-automation-controller/pull/263 for `reconcilers-dev` branch.