### PR TITLE
Set default observedGeneration to -1

### DIFF
--- a/api/v1beta1/imageupdateautomation_types.go
+++ b/api/v1beta1/imageupdateautomation_types.go
@@ -129,7 +129,8 @@ type ImageUpdateAutomation struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ImageUpdateAutomationSpec   `json:"spec,omitempty"`
+	Spec ImageUpdateAutomationSpec `json:"spec,omitempty"`
+	// +kubebuilder:default={"observedGeneration":-1}
 	Status ImageUpdateAutomationStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -690,6 +690,8 @@ spec:
             - sourceRef
             type: object
           status:
+            default:
+              observedGeneration: -1
             description: ImageUpdateAutomationStatus defines the observed state of
               ImageUpdateAutomation
             properties:


### PR DESCRIPTION
Sets a default value of -1 for the `observedGeneration` field of the ImageUpdateAutomations type `status.observedGeneration` attribute. This ensures that tools like `kstatus` do not consider the resource to be in a Ready state prematurely because the `generation` and `observedGeneration` attributes are briefly initialized with `0` values.

- https://github.com/fluxcd/flux2/issues/2007
- https://github.com/fluxcd/image-automation-controller/issues/275

Credits to @tomhuang12 for his prior work on fluxcd/image-reflector-controller#189
