### PR TITLE
Configure libgit2 fetch and push ProxyOptions

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -652,6 +652,7 @@ func fetch(ctx context.Context, path string, branch string, access repoAccess) e
 		[]string{refspec},
 		&libgit2.FetchOptions{
 			RemoteCallbacks: access.remoteCallbacks(ctx),
+			ProxyOptions:    libgit2.ProxyOptions{Type: libgit2.ProxyTypeAuto},
 		}, "",
 	)
 	if err != nil && libgit2.IsErrorCode(err, libgit2.ErrorCodeNotFound) {
@@ -689,6 +690,7 @@ func push(ctx context.Context, path, branch string, access repoAccess) error {
 	}
 	err = origin.Push([]string{fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch)}, &libgit2.PushOptions{
 		RemoteCallbacks: callbacks,
+		ProxyOptions:    libgit2.ProxyOptions{Type: libgit2.ProxyTypeAuto},
 	})
 	if err != nil {
 		return libgit2PushError(err)

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-containerregistry v0.6.0
-	github.com/libgit2/git2go/v31 v31.6.1
+	github.com/libgit2/git2go/v31 v31.7.6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
 	github.com/otiai10/copy v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -674,8 +674,9 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtB
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/libgit2/git2go/v31 v31.6.1 h1:FnKHHDDBgltSsu9RpKuL4rSR8dQ1JTf9dfvFhZ1y7Aw=
 github.com/libgit2/git2go/v31 v31.6.1/go.mod h1:c/rkJcBcUFx6wHaT++UwNpKvIsmPNqCeQ/vzO4DrEec=
+github.com/libgit2/git2go/v31 v31.7.6 h1:jg/pNomrQULnafmfF6XTkozPX5ypyELoWErWkJuYPcI=
+github.com/libgit2/git2go/v31 v31.7.6/go.mod h1:c/rkJcBcUFx6wHaT++UwNpKvIsmPNqCeQ/vzO4DrEec=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
Similarly to https://github.com/fluxcd/source-controller/pull/524, this PR allows to specify an HTTP(S) proxy for Git operations through environment variables.

Fixes https://github.com/fluxcd/image-automation-controller/issues/279.

This is a draft for now because the current version of git2go's bindings do not allow to specify ProxyOptions for push operations, only for clone and fetch.
It first requires https://github.com/libgit2/git2go/pull/872 to be merged and backported to release-1.1 (v31), which is the version of libgit2 used by image-automation-controller (and source-controller).