### PR TITLE
Log the error when removing the working dir fails

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -215,7 +215,11 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 	if err != nil {
 		return failWithError(err)
 	}
-	defer os.RemoveAll(tmp)
+	defer func() {
+		if err := os.RemoveAll(tmp); err != nil {
+			log.Error(err, "failed to remove working directory", "path", tmp)
+		}
+	}()
 
 	// FIXME use context with deadline for at least the following ops
 


### PR DESCRIPTION
os.RemoveAll can return an error; even if we're exiting the procedure
at the time, it's worth knowing when it's failing, because typically
the working directory is a memory-backed volume and you can run out
quite easily.
