### PR TITLE
Update kyaml to v0.13.0

### DIFF
--- a/controllers/testdata/appconfig-expected/deploy.yaml
+++ b/controllers/testdata/appconfig-expected/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: hello
-          image: helloworld:1.0.1 # SETTER_SITE
+      - name: hello
+        image: helloworld:1.0.1 # SETTER_SITE

--- a/controllers/testdata/appconfig-expected2/deploy.yaml
+++ b/controllers/testdata/appconfig-expected2/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: hello
-          image: helloworld:1.2.0 # SETTER_SITE
+      - name: hello
+        image: helloworld:1.2.0 # SETTER_SITE

--- a/controllers/testdata/appconfig-setters-expected/deploy.yaml
+++ b/controllers/testdata/appconfig-setters-expected/deploy.yaml
@@ -6,5 +6,5 @@ spec:
   template:
     spec:
       containers:
-        - name: hello
-          image: helloworld:1.0.1 # SETTER_SITE
+      - name: hello
+        image: helloworld:1.0.1 # SETTER_SITE

--- a/go.mod
+++ b/go.mod
@@ -125,5 +125,5 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-// pink kyaml to prevent indent changes
-replace sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.10.21
+// pin kustomize to v4.4.1
+replace sigs.k8s.io/kustomize/kyaml => sigs.k8s.io/kustomize/kyaml v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -1658,8 +1658,8 @@ sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH8
 sigs.k8s.io/kustomize/api v0.10.1/go.mod h1:2FigT1QN6xKdcnGS2Ppp1uIWrtWN28Ms8A3OZUZhwr8=
 sigs.k8s.io/kustomize/cmd/config v0.9.13/go.mod h1:7547FLF8W/lTaDf0BDqFTbZxM9zqwEJqCKN9sSR0xSs=
 sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcLwfqwzTRHW3kv5go=
-sigs.k8s.io/kustomize/kyaml v0.10.21 h1:KdoEgz3HzmcaLUTFqs6aaqFpsaA9MVRIwOZbi8vMaD0=
-sigs.k8s.io/kustomize/kyaml v0.10.21/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
+sigs.k8s.io/kustomize/kyaml v0.13.0 h1:9c+ETyNfSrVhxvphs+K2dzT3dh5oVPPEqPOE/cUpScY=
+sigs.k8s.io/kustomize/kyaml v0.13.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/pkg/update/testdata/replace/expected/cronjob.yaml
+++ b/pkg/update/testdata/replace/expected/cronjob.yaml
@@ -10,5 +10,5 @@ spec:
       template:
         spec:
           containers:
-            - name: c
-              image: used:v1.1.0
+          - name: c
+            image: used:v1.1.0

--- a/pkg/update/testdata/replace/expected/deployment.yaml
+++ b/pkg/update/testdata/replace/expected/deployment.yaml
@@ -7,5 +7,5 @@ spec:
   template:
     spec:
       containers:
-        - name: c
-          image: used:v1.1.0
+      - name: c
+        image: used:v1.1.0

--- a/pkg/update/testdata/setters/expected/kustomization.yaml
+++ b/pkg/update/testdata/setters/expected/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - unimportant.yaml
+- unimportant.yaml
 images:
-  - name: container
-    newName: index.repo.fake/updated # {"$imagepolicy": "automation-ns:policy:name"}
-    newTag: v1.0.1 # {"$imagepolicy": "automation-ns:policy:tag"}
+- name: container
+  newName: index.repo.fake/updated # {"$imagepolicy": "automation-ns:policy:name"}
+  newTag: v1.0.1 # {"$imagepolicy": "automation-ns:policy:tag"}

--- a/pkg/update/testdata/setters/expected/marked.yaml
+++ b/pkg/update/testdata/setters/expected/marked.yaml
@@ -10,7 +10,7 @@ spec:
       template:
         spec:
           containers:
-            - name: c
-              image: index.repo.fake/updated:v1.0.1 # {"$imagepolicy": "automation-ns:policy"}
-            - name: d
-              image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}
+          - name: c
+            image: index.repo.fake/updated:v1.0.1 # {"$imagepolicy": "automation-ns:policy"}
+          - name: d
+            image: image:v1.0.0 # {"$imagepolicy": "automation-ns:unchanged"}


### PR DESCRIPTION
Updating kyaml to match the version we use in other components. This
version's most significant change for us would be that kyaml will no
longer override indentations in the targeted files.