### PR TITLE
Fix makefile envtest and controller-gen usage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Set up kubebuilder
-      uses: fluxcd/pkg/actions/kubebuilder@main
-    - name: Setup envtest
-      uses: fluxcd/pkg/actions/envtest@main
-      with:
-        version: "1.19.2"
     - name: Run tests
       uses: ./.github/actions/run-tests
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ controllers/testdata/crds/*
 *.so
 *.dylib
 bin
+testbin
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
Refactor logic to install helper tools into one function in the
Makefile. Add support for envtest to help install tools like kubectl,
etcd which helps users run tests more conveniently.

Ref: https://github.com/fluxcd/flux2/issues/2273

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>