### PR TITLE
Drop capabilities, enable seccomp and enforce runAsNonRoot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,6 @@ FROM prepare-${BASE_VARIANT} as build
 
 FROM debian:${BASE_VARIANT}-slim as controller
 
-# Configure user
-RUN groupadd controller && \
-    useradd --gid controller --shell /bin/sh --create-home controller
-
 # Copy libgit2
 COPY --from=build /libgit2/lib/ /usr/local/lib/
 RUN ldconfig
@@ -90,5 +86,6 @@ RUN echo "deb http://deb.debian.org/debian sid main" >> /etc/apt/sources.list \
 # Copy over binary from build
 COPY --from=build /workspace/image-automation-controller /usr/local/bin/
 
-USER controller
+USER 65534:65534
+
 ENTRYPOINT [ "image-automation-controller" ]

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -29,6 +29,11 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: [ "ALL" ]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
           - containerPort: 8080
             name: http-prom


### PR DESCRIPTION
Further restricts the SecurityContext that the controller runs under, by enabling the default seccomp profile and dropping all linux capabilities.
This was set at container-level to ensure backwards compatibility with use cases in which sidecars are injected into the source-controller pod
without setting less restrictive settings.
Add a uid and gid for the container to enforce runAsNonRoot and ensure
the use of non root users.

Ref: fluxcd/flux2#2014

BREAKING CHANGES:
1) The use of new seccomp API requires Kubernetes 1.19.
2) the controller container is now executed under 65534:65534 (userid:groupid).
   This change may break deployments that hard-coded the user name 'controller' in their PodSecurityPolicy.

Signed-off-by: Sanskar Jaiswal <sanskar.jaiswal@weave.works>
Co-authored-by: Paulo Gomes <paulo.gomes@weave.works>