### PR TITLE
Unset libgit2 timeout callbacks

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -490,7 +490,15 @@ func (r *ImageUpdateAutomationReconciler) getRepoAccess(ctx context.Context, rep
 }
 
 func (r repoAccess) remoteCallbacks(ctx context.Context) libgit2.RemoteCallbacks {
-	return gitlibgit2.RemoteCallbacks(ctx, r.auth)
+	callbacks := gitlibgit2.RemoteCallbacks(ctx, r.auth)
+
+	// Unset timeout related callbacks in an attempt to resolve
+	// https://github.com/fluxcd/image-automation-controller/issues/296
+	callbacks.SidebandProgressCallback = nil
+	callbacks.TransferProgressCallback = nil
+	callbacks.PushTransferProgressCallback = nil
+
+	return callbacks
 }
 
 // cloneInto clones the upstream repository at the `ref` given (which


### PR DESCRIPTION
In an attempt to see if this magically solves the issue that has been
reported about the controller getting "stuck" while attempting to clone
larger repositories.

**Testing image**: `ghcr.io/fluxcd/image-automation-controller:rc-4d5a781b`

Ref: https://github.com/fluxcd/image-automation-controller/issues/296