### PR TITLE
Remove direct dependency to go-git

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,6 @@ require (
 	// If you bump this, change SOURCE_VER in the Makefile to match
 	github.com/fluxcd/source-controller v0.21.3-0.20220222161537-bd3d7817d0cf
 	github.com/fluxcd/source-controller/api v0.21.3-0.20220222161537-bd3d7817d0cf
-	github.com/go-git/go-billy/v5 v5.3.1
-	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.2
 	github.com/google/go-containerregistry v0.6.0
 	github.com/libgit2/git2go/v33 v33.0.7
@@ -55,6 +53,8 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.3.1 // indirect
+	github.com/go-git/go-git/v5 v5.4.2 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect


### PR DESCRIPTION
Consolidates the use of `libgit2` for all operations done by the controller.

### Context on tests

Given the [the connection issues documented](https://docs.google.com/document/d/1WGR2fP1AtShn8zAsQwcS-r-dt_7kBLwGqzHxxnnHOvA/) and [reported](https://github.com/fluxcd/image-automation-controller/issues/293), I did a long run on this PR to ensure this won't make matters worse.
 
This has been tested for over 24h in a patchy network and it seems to be causing slightly less errors when cloning git repositories. In such environment I tend to get one of the following error messages every 1-3 hours:

```
unable to clone 'ssh://git@github.com/<repo>': transport closed
unable to clone 'ssh://git@github.com/<repo>: SSH could not read data: Error waiting on socket
unable to clone 'ssh://git@github.com/<repo>: failed to connect to github.com: Operation timed out
Failed to retrieve list of SSH authentication methods: Failed getting response
```

With this version the errors seem to have decrease in frequency to once every 6-7 hours. The range of errors seem to also have decreased:
```
unable to clone 'ssh://git@github.com/<repo>': failed to connect to github.com: Operation timed out
unable to clone 'ssh://git@github.com/<repo>': SSH could not read data: Error waiting on socket
```

Fixes #323 