### PR TITLE
Fix bug when pushing into different branch

### DIFF
--- a/controllers/git_test.go
+++ b/controllers/git_test.go
@@ -134,6 +134,9 @@ func TestPushRejected(t *testing.T) {
 
 	repoURL := gitServer.HTTPAddressWithCredentials() + "/appconfig.git"
 	repo, err := clone(repoURL, "origin", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// This is here to guard against push in general being broken
 	err = push(context.TODO(), repo.Workdir(), "main", repoAccess{


### PR DESCRIPTION
Changes replacing go-git with git2go introduced a bug in which pushes into new branches squashes all commits into one.

Relates to: https://github.com/fluxcd/image-automation-controller/issues/329