### PR TITLE
Update libgit2 to 1.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.17
 ARG XX_VERSION=1.1.0
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-ARG LIBGIT2_TAG=libgit2-1.3.0-2
+ARG LIBGIT2_TAG=libgit2-1.3.1
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2
-LIBGIT2_TAG ?= libgit2-1.3.0-2
+LIBGIT2_TAG ?= libgit2-1.3.1
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-libgit2-1.3.0-2}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-libgit2-1.3.1}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/image-automation-controller"


### PR DESCRIPTION
Image libgit2-v1.3.1 has the change below:

Update libgit2 to libgit2-v1.3.1:
This is a security release to provide compatibility with git's changes to address [CVE-2022-24765](https://ubuntu.com/security/CVE-2022-24765).
https://github.com/libgit2/libgit2/compare/v1.3.0...v1.3.1

Update OpenSSL to openssl-3.0.2:
Minor changes
https://github.com/openssl/openssl/compare/openssl-3.0.1...openssl-3.0.2

Update libz to libz-v1.2.12:
Minor changes
https://github.com/madler/zlib/compare/v1.2.11...v1.2.12

Tests:
- [x] Development on `linux-amd64`.
- [x] Development on `darwin-arm`.
- [x] K8S Cluster on `arm/v7` (raspberry Pi).
- [x] K8S Cluster on `linux-amd64`.

xref: https://github.com/fluxcd/golang-with-libgit2/pull/22