### PR TITLE
Instruct kyaml/kio to retain sequence indentation style

### DIFF
--- a/pkg/update/filereader.go
+++ b/pkg/update/filereader.go
@@ -118,8 +118,9 @@ func (r *ScreeningLocalReader) Read() ([]*yaml.RNode, error) {
 
 		tracelog.Info("reading file", "path", path)
 		rdr := &kio.ByteReader{
-			Reader:         bytes.NewBuffer(filebytes),
-			SetAnnotations: annotations,
+			Reader:            bytes.NewBuffer(filebytes),
+			SetAnnotations:    annotations,
+			PreserveSeqIndent: true,
 		}
 
 		nodes, err := rdr.Read()


### PR DESCRIPTION
...to avoid annoying whitespace changes when image automation controller performs updates. This is a follow-up to https://github.com/fluxcd/image-automation-controller/issues/68#issuecomment-775816455 - using the feature added to kyaml/kio in https://github.com/kubernetes-sigs/kustomize/pull/4043.