### PR TITLE
Update go-restful to v3.8.0

### DIFF
--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -714,6 +714,9 @@ func TestImageAutomationReconciler_e2e(t *testing.T) {
 				if err := testEnv.Get(context.Background(), updateKey, obj); err != nil {
 					return false
 				}
+				if len(obj.Finalizers) == 0 {
+					return false
+				}
 				return true
 			}, timeout, time.Second).Should(BeTrue())
 

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,9 @@ require (
 // Fix CVE-2022-28948
 replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.0
 
+// Fix CVE-2022-1996
+replace github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.8.0
+
 require (
 	cloud.google.com/go/compute v1.6.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.7.5-0.20220308211933-7c971ca4d0fd h1:iKIUl3SetleviJ07WJdKqdvVBzmfYgaADXHHrONYPOY=
-github.com/emicklei/go-restful/v3 v3.7.5-0.20220308211933-7c971ca4d0fd/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
+github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=


### PR DESCRIPTION
Fix CVE-2022-1996