### PR TITLE
build: provenance and tampering checks for libgit2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BASE_VARIANT=alpine
 ARG GO_VERSION=1.18
 ARG XX_VERSION=1.1.0
 
-ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2
-ARG LIBGIT2_TAG=libgit2-1.3.1
+ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-all
+ARG LIBGIT2_TAG=v0.1.1
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -212,8 +212,11 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 libgit2: $(LIBGIT2)  ## Detect or download libgit2 library
 
+COSIGN = $(GOBIN)/cosign
 $(LIBGIT2): $(MUSL-CC)
-	IMG=$(LIBGIT2_IMG) TAG=$(LIBGIT2_TAG) ./hack/install-libraries.sh
+	$(call go-install-tool,$(COSIGN),github.com/sigstore/cosign/cmd/cosign@latest)
+
+	IMG=$(LIBGIT2_IMG) TAG=$(LIBGIT2_TAG) PATH=$(PATH):$(GOBIN) ./hack/install-libraries.sh
 
 $(MUSL-CC):
 ifneq ($(shell uname -s),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ TAG ?= latest
 CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Base image used to build the Go binary
-LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2
-LIBGIT2_TAG ?= libgit2-1.3.1
+LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2-all
+LIBGIT2_TAG ?= v0.1.1
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace github.com/fluxcd/image-automation-controller/api => ./api
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/ProtonMail/go-crypto v0.0.0-20220623141421-5afb4c282135
+	github.com/ProtonMail/go-crypto v0.0.0-20220711121315-1fde58898e96
 	github.com/cyphar/filepath-securejoin v0.2.3
 	github.com/fluxcd/image-automation-controller/api v0.23.4
 	github.com/fluxcd/image-reflector-controller/api v0.19.2

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,9 @@ require (
 // Fix CVE-2022-28948
 replace gopkg.in/yaml.v3 => gopkg.in/yaml.v3 v3.0.1
 
+// Fix CVE-2022-1996 (for v2, Go Modules incompatible)
+replace github.com/emicklei/go-restful => github.com/emicklei/go-restful v2.16.0+incompatible
+
 // Fix CVE-2022-1996
 replace github.com/emicklei/go-restful/v3 => github.com/emicklei/go-restful/v3 v3.8.0
 

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,7 @@ github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/ProtonMail/go-crypto v0.0.0-20220623141421-5afb4c282135 h1:xDc/cFH/hwyr9KyWc0sm26lpsscqtfZBvU8NpRLHwJ0=
-github.com/ProtonMail/go-crypto v0.0.0-20220623141421-5afb4c282135/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/ProtonMail/go-crypto v0.0.0-20220711121315-1fde58898e96 h1:RPb1m9BO0rsapVO7TYlWvjdJ5c1h/EWsEPT0f5IoJXs=
+github.com/ProtonMail/go-crypto v0.0.0-20220711121315-1fde58898e96/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=

--- a/hack/install-libraries.sh
+++ b/hack/install-libraries.sh
@@ -5,8 +5,98 @@ set -euxo pipefail
 IMG="${IMG:-}"
 TAG="${TAG:-}"
 IMG_TAG="${IMG}:${TAG}"
+DOWNLOAD_URL="https://github.com/fluxcd/golang-with-libgit2/releases/download/${TAG}"
 
-function extract(){
+TMP_DIR=$(mktemp -d)
+
+function cleanup(){
+    rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+fatal() {
+    echo '[ERROR] ' "$@" >&2
+    exit 1
+}
+
+download() {
+    [[ $# -eq 2 ]] || fatal 'download needs exactly 2 arguments'
+
+    curl -o "$1" -sfL "$2"
+
+    [[ $? -eq 0 ]] || fatal 'Download failed'
+}
+
+download_files() {
+    [[ $# -eq 1 ]] || fatal 'download_files needs exactly 1 arguments'
+
+    FILE_NAMES="checksums.txt checksums.txt.sig checksums.txt.pem $1"
+
+    for FILE_NAME in ${FILE_NAMES}; do
+        download "${TMP_DIR}/${FILE_NAME}" "${DOWNLOAD_URL}/${FILE_NAME}"
+    done    
+}
+
+cosign_verify(){
+    [[ $# -eq 3 ]] || fatal 'cosign_verify needs exactly 3 arguments'
+
+    cosign verify-blob --cert "$1" --signature "$2" "$3"
+    
+    [[ $? -eq 0 ]] || fatal 'signature verification failed'
+}
+
+assure_provenance() {
+    [[ $# -eq 1 ]] || fatal 'assure_provenance needs exactly 1 arguments'
+
+    cosign_verify "${TMP_DIR}/checksums.txt.pem" \
+                  "${TMP_DIR}/checksums.txt.sig" \
+                  "${TMP_DIR}/checksums.txt"
+
+    pushd "${TMP_DIR}" || exit
+    if command -v sha256sum; then
+        grep "$1" "checksums.txt" | sha256sum --check
+    else
+        grep "$1" "checksums.txt" | shasum -a 256 --check
+    fi
+    popd || exit
+        
+    [[ $? -eq 0 ]] || fatal 'integrity verification failed'
+}
+
+extract_libraries(){
+    [[ $# -eq 2 ]] || fatal 'extract_libraries needs exactly 2 arguments'
+
+    tar -xf "${TMP_DIR}/$1"
+
+    rm "${TMP_DIR}/$1"
+    mv "${2}" "${TAG}"
+    mv "${TAG}/" "./build/libgit2"
+}
+
+fix_pkgconfigs(){
+    DIR="$1"
+    NEW_DIR="$(/bin/pwd)/build/libgit2/${TAG}"
+
+    # Update the prefix paths included in the .pc files.
+    if [[ $OSTYPE == 'darwin'* ]]; then
+        INSTALLED_DIR="/Users/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
+
+        # This will make it easier to update to the location in which they will be used.
+        # sed has a sight different behaviour in MacOS
+        # NB: Some macOS users may override their sed with gsed. If gsed is the PATH, use that instead.
+        if command -v gsed &> /dev/null; then 
+            find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} gsed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
+        else
+            find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "" "s;${INSTALLED_DIR};${NEW_DIR};g" {}
+        fi
+    else
+        INSTALLED_DIR="/home/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
+    
+        find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
+    fi
+}
+
+extract_from_image(){
     PLATFORM=$1
     DIR=$2
 
@@ -16,13 +106,6 @@ function extract(){
 
     tar -xf output.tar.gz "local/${DIR}"
     rm output.tar.gz
-}
-
-function setup() {
-    PLATFORM=$1
-    DIR=$2
-
-    extract "${PLATFORM}" "${DIR}"
 
     NEW_DIR="$(/bin/pwd)/build/libgit2/${TAG}"
     INSTALLED_DIR="/usr/local/${DIR}"
@@ -36,62 +119,34 @@ function setup() {
     find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
 }
 
-function setup_current() {
+install_libraries(){
     if [ -d "./build/libgit2/${TAG}" ]; then
-        echo "Skipping libgit2 setup as it already exists"
+        echo "Skipping: libgit2 ${TAG} already installed"
         exit 0
     fi
 
     mkdir -p "./build/libgit2"
-    if [[ $OSTYPE == 'darwin'* ]]; then
-        # For MacOS development environments, download the amd64 static libraries released from from golang-with-libgit2.
 
-        curl -o output.tar.gz -LO "https://github.com/fluxcd/golang-with-libgit2/releases/download/${TAG}/darwin-libs.tar.gz"
-
-        DIR=libgit2-darwin
-        NEW_DIR="$(/bin/pwd)/build/libgit2/${TAG}"
-        INSTALLED_DIR="/Users/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}-amd64"
-
-        tar -xf output.tar.gz
-        rm output.tar.gz
-        mv "${DIR}" "${TAG}"
-        mv "${TAG}/" "./build/libgit2"
-
-        LIBGIT2_SED="s;-L/Applications/Xcode_.* ;;g"
-        LIBGIT2PC="$(/bin/pwd)/build/libgit2/${TAG}/lib/pkgconfig/libgit2.pc"
-        # Some macOS users may override their sed with gsed. If gsed is the PATH, use that instead.
-        if command -v gsed &> /dev/null; then
-            # Removes abs path from build machine, and let iconv be resolved automatically by default search paths.
-            gsed -i "${LIBGIT2_SED}" "${LIBGIT2PC}"
-
-            # Update the prefix paths included in the .pc files.
-            # This will make it easier to update to the location in which they will be used.
-            # sed has a sight different behaviour in MacOS
-            find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} gsed -i "s;${INSTALLED_DIR};${NEW_DIR};g" {}
-        else
-            # Removes abs path from build machine, and let iconv be resolved automatically by default search paths.
-            sed -i "" "${LIBGIT2_SED}" "${LIBGIT2PC}"
-
-            # Update the prefix paths included in the .pc files.
-            # This will make it easier to update to the location in which they will be used.
-            # sed has a sight different behaviour in MacOS
-            find "${NEW_DIR}" -type f -name "*.pc" | xargs -I {} sed -i "" "s;${INSTALLED_DIR};${NEW_DIR};g" {}
+    # Linux ARM support is still based on the container image libraries.
+    if [[ $OSTYPE == 'linux'* ]]; then
+        if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+            extract_from_image "linux/arm64" "aarch64-alpine-linux-musl"
+            fix_pkgconfigs "aarch64-alpine-linux-musl"
+            exit 0
         fi
-    else
-        # for linux development environments, use the static libraries from the official container images.
-        DIR="x86_64-alpine-linux-musl"
-        PLATFORM="linux/amd64"
-
-        if [[ "$(uname -m)" == armv7* ]]; then
-            DIR="armv7-alpine-linux-musleabihf"
-            PLATFORM="linux/arm/v7"
-        elif [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
-            DIR="aarch64-alpine-linux-musl"
-            PLATFORM="linux/arm64"
-        fi
-        
-        setup "${PLATFORM}" "${DIR}"
     fi
+
+    FILE_NAME="linux-$(uname -m)-all-libs.tar.gz"
+    DIR="libgit2-linux-all-libs"
+    if [[ $OSTYPE == 'darwin'* ]]; then
+        FILE_NAME="darwin-all-libs.tar.gz"
+        DIR="darwin-all-libs"
+    fi
+
+    download_files "${FILE_NAME}"
+    assure_provenance "${FILE_NAME}"
+    extract_libraries "${FILE_NAME}" "${DIR}"
+    fix_pkgconfigs "${DIR}"
 }
 
-setup_current
+install_libraries

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-libgit2-1.3.1}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-v0.1.1}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/image-automation-controller"
@@ -28,9 +28,9 @@ export TARGET_DIR="$(/bin/pwd)/build/libgit2/${LIBGIT2_TAG}"
 # For most cases, libgit2 will already be present.
 # The exception being at the oss-fuzz integration.
 if [ ! -d "${TARGET_DIR}" ]; then
-    curl -o output.tar.gz -LO "https://github.com/fluxcd/golang-with-libgit2/releases/download/${LIBGIT2_TAG}/linux-$(uname -m)-libs.tar.gz"
+    curl -o output.tar.gz -LO "https://github.com/fluxcd/golang-with-libgit2/releases/download/${LIBGIT2_TAG}/linux-$(uname -m)-all-libs.tar.gz"
 
-    DIR=libgit2-linux
+    DIR=libgit2-linux-all-libs
     NEW_DIR="$(/bin/pwd)/build/libgit2/${LIBGIT2_TAG}"
     INSTALLED_DIR="/home/runner/work/golang-with-libgit2/golang-with-libgit2/build/${DIR}"
 


### PR DESCRIPTION
Changes:
- Fixes github.com/emicklei/go-restful (GHSA-r48q-9g5r-8q2h).
- Update dependencies.
- Add provenance and tampering checks for libgit2.


Closes #404.