### PR TITLE
Update libgit2 to v1.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.18
 ARG XX_VERSION=1.1.0
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-all
-ARG LIBGIT2_TAG=v0.1.1
+ARG LIBGIT2_TAG=v0.1.2
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2-all
-LIBGIT2_TAG ?= v0.1.1
+LIBGIT2_TAG ?= v0.1.2
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-v0.1.1}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-v0.1.2}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/image-automation-controller"


### PR DESCRIPTION
Updates `golang-with-libgit2-all` to `v0.1.2` which contains `libgit2-1.3.2`.

Test image: `ghcr.io/fluxcd/image-automation-controller:rc-63a1d43e`