### PR TITLE
build: Ignore CI workflows for markdown files

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,11 @@
 name: build
 on:
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'MAINTAINERS'
+      - 'CHANGELOG.md'
+
   push:
     branches:
     - main

--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
 
+    paths-ignore:
+      - 'README.md'
+      - 'MAINTAINERS'
+      - 'CHANGELOG.md'
+      - 'config/manager/kustomization.yaml'
+
 permissions:
   contents: read
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
+    paths-ignore:
+      - 'README.md'
+      - 'MAINTAINERS'
+      - 'CHANGELOG.md'
+      - 'config/manager/kustomization.yaml'
+
   schedule:
     - cron: '18 10 * * 3'
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/ProtonMail/go-crypto v0.0.0-20220730123233-d6ffb7692adf
 	github.com/cyphar/filepath-securejoin v0.2.3
-	github.com/fluxcd/image-automation-controller/api v0.24.0
+	github.com/fluxcd/image-automation-controller/api v0.0.0 // redundant based on replace above
 	github.com/fluxcd/image-reflector-controller/api v0.20.0
 	github.com/fluxcd/pkg/apis/acl v0.0.3
 	github.com/fluxcd/pkg/apis/meta v0.14.2


### PR DESCRIPTION
Running all CI tests at pull requests for some files are not as relevant as to others. For example, release PRs contains changes to CHANGELOG.md only, and none of the tests executed in CI assess that file.

