### PR TITLE
Enable RecoverPanic

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -96,6 +96,7 @@ type ImageUpdateAutomationReconciler struct {
 type ImageUpdateAutomationReconcilerOptions struct {
 	MaxConcurrentReconciles int
 	RateLimiter             ratelimiter.RateLimiter
+	RecoverPanic            bool
 }
 
 // +kubebuilder:rbac:groups=image.toolkit.fluxcd.io,resources=imageupdateautomations,verbs=get;list;watch;create;update;patch;delete
@@ -443,6 +444,7 @@ func (r *ImageUpdateAutomationReconciler) SetupWithManager(mgr ctrl.Manager, opt
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: opts.MaxConcurrentReconciles,
 			RateLimiter:             opts.RateLimiter,
+			RecoverPanic:            opts.RecoverPanic,
 		}).
 		Complete(r)
 }

--- a/main.go
+++ b/main.go
@@ -50,7 +50,12 @@ import (
 	"github.com/fluxcd/image-automation-controller/controllers"
 )
 
-const controllerName = "image-automation-controller"
+const (
+	controllerName = "image-automation-controller"
+
+	// recoverPanic indicates whether panic caused by reconciles should be recovered.
+	recoverPanic = true
+)
 
 var (
 	scheme   = runtime.NewScheme()
@@ -155,6 +160,7 @@ func main() {
 	}).SetupWithManager(mgr, controllers.ImageUpdateAutomationReconcilerOptions{
 		MaxConcurrentReconciles: concurrent,
 		RateLimiter:             helper.GetRateLimiter(rateLimiterOptions),
+		RecoverPanic:            recoverPanic,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageUpdateAutomation")
 		os.Exit(1)


### PR DESCRIPTION
The controller-runtime provides the ability to recover from panics that have arisen from a reconciliation. 
This change enables this functionality by default.


Decreases the impact of #415.

Part of: https://github.com/fluxcd/flux2/issues/2952