### PR TITLE
fuzz: Ensure Go 1.18 for fuzz image

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18.x
     - name: Restore Go cache
       uses: actions/cache@v3
       with:

--- a/tests/fuzz/Dockerfile.builder
+++ b/tests/fuzz/Dockerfile.builder
@@ -1,4 +1,9 @@
+FROM golang:1.18 AS go
+
 FROM gcr.io/oss-fuzz-base/base-builder-go
+
+# ensures golang 1.18 to enable go native fuzzing.
+COPY --from=go /usr/local/go /usr/local/
 
 RUN apt-get update && apt-get install -y cmake pkg-config
 


### PR DESCRIPTION
Changes:
- Upgrade fuzz container to Go 1.18.
- Upgrade worker to Go 1.18.

Fixes CIFuzz failures: https://github.com/fluxcd/image-automation-controller/runs/8013565384?check_suite_focus=true