### PR TITLE
Aligns output with source-controller on no-ops

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -388,7 +388,7 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 			return failWithError(err)
 		}
 
-		debuglog.Info("no changes made in working directory; no commit")
+		log.Info("no changes made in working directory; no commit")
 		statusMessage = "no updates made"
 
 		if auto.Status.LastPushTime != nil && len(auto.Status.LastPushCommit) >= 7 {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -70,7 +70,6 @@ func TestMain(m *testing.M) {
 	controllerName := "image-automation-controller"
 	if err := (&ImageUpdateAutomationReconciler{
 		Client:        testEnv,
-		Scheme:        scheme.Scheme,
 		EventRecorder: testEnv.GetEventRecorderFor(controllerName),
 	}).SetupWithManager(testEnv, ImageUpdateAutomationReconcilerOptions{}); err != nil {
 		panic(fmt.Sprintf("Failed to start ImageUpdateAutomationReconciler: %v", err))

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -43,7 +43,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -250,7 +249,6 @@ func TestImageAutomationReconciler_crossNamespaceRef(t *testing.T) {
 	builder := fakeclient.NewClientBuilder().WithScheme(testEnv.Scheme())
 	r := &ImageUpdateAutomationReconciler{
 		Client:              builder.Build(),
-		Scheme:              scheme.Scheme,
 		EventRecorder:       testEnv.GetEventRecorderFor("image-automation-controller"),
 		NoCrossNamespaceRef: true,
 	}
@@ -731,7 +729,6 @@ func TestImageAutomationReconciler_e2e(t *testing.T) {
 			// explicitly.
 			imageAutoReconciler := &ImageUpdateAutomationReconciler{
 				Client: testEnv,
-				Scheme: scheme.Scheme,
 			}
 
 			// Wait for the suspension to reach the cache

--- a/tests/fuzz/image_update_fuzzer.go
+++ b/tests/fuzz/image_update_fuzzer.go
@@ -178,7 +178,6 @@ func FuzzImageUpdateReconciler(data []byte) int {
 		utilruntime.Must(ensureDependencies(func(m manager.Manager) {
 			utilruntime.Must((&controllers.ImageUpdateAutomationReconciler{
 				Client: m.GetClient(),
-				Scheme: scheme.Scheme,
 			}).SetupWithManager(m, controllers.ImageUpdateAutomationReconcilerOptions{MaxConcurrentReconciles: 4}))
 		}))
 	})


### PR DESCRIPTION
No-op reconciliations now yield a message such as below even when log level is set to `info`, which aligns with source-controller behaviour:
```
{"level":"info","ts":"2022-09-05T08:43:59.516Z","msg":"no changes made in working directory; no commit","controller":"imageupdateautomation","controllerGroup":"image.toolkit.fluxcd.io","controllerKind":"ImageUpdateAutomation","imageUpdateAutomation":{"name":"github-branch","namespace":"flux-system"},"namespace":"flux-system","name":"github-branch","reconcileID":"4ee714d8-5986-45fd-9f54-33d882b81cde"}
```

Custom code to record metrics was replaced with `helper.Metrics`.