### PR TITLE
api: add custom validation for v1.Duration types

### DIFF
--- a/api/v1beta1/imageupdateautomation_types.go
+++ b/api/v1beta1/imageupdateautomation_types.go
@@ -44,6 +44,8 @@ type ImageUpdateAutomationSpec struct {
 
 	// Interval gives an lower bound for how often the automation
 	// run should be attempted.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ms|s|m|h))+$"
 	// +required
 	Interval metav1.Duration `json:"interval"`
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -648,6 +648,7 @@ spec:
               interval:
                 description: Interval gives an lower bound for how often the automation
                   run should be attempted.
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
               sourceRef:
                 description: SourceRef refers to the resource giving access details


### PR DESCRIPTION
To solve discrepancies between parsing versus validation.

xref: https://github.com/kubernetes/apimachinery/issues/131