### PR TITLE
build: Bump CI to macos-11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,10 +55,10 @@ jobs:
       - name: Verify
         run: make verify
 
-  # Runs 'make test' on macos-10.15 to assure development environment for
+  # Runs 'make test' on macos-11 to assure development environment for
   # contributors using MacOS.
   darwin-amd64:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The previous version has been deprecated and should not be used going forwards.

More info at https://github.com/actions/runner-images/issues/5583.