### PR TITLE
build: Bump golang-with-libgit2 to v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.19
 ARG XX_VERSION=1.1.2
 
 ARG LIBGIT2_IMG=ghcr.io/fluxcd/golang-with-libgit2-only
-ARG LIBGIT2_TAG=v0.3.0
+ARG LIBGIT2_TAG=v0.4.0
 
 FROM ${LIBGIT2_IMG}:${LIBGIT2_TAG} AS libgit2-libs
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CRD_OPTIONS ?= crd:crdVersions=v1
 
 # Base image used to build the Go binary
 LIBGIT2_IMG ?= ghcr.io/fluxcd/golang-with-libgit2-only
-LIBGIT2_TAG ?= v0.3.0
+LIBGIT2_TAG ?= v0.4.0
 
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	git2go "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/update_test.go
+++ b/controllers/update_test.go
@@ -33,8 +33,8 @@ import (
 
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/go-logr/logr"
-	git2go "github.com/libgit2/git2go/v33"
-	libgit2 "github.com/libgit2/git2go/v33"
+	git2go "github.com/libgit2/git2go/v34"
+	libgit2 "github.com/libgit2/git2go/v34"
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
 	"golang.org/x/crypto/openpgp"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,10 @@ replace github.com/fluxcd/image-automation-controller/api => ./api
 // For more information refer to:
 // - fluxcd/image-automation-controller/#339.
 // - libgit2/git2go#918.
-replace github.com/libgit2/git2go/v33 => github.com/fluxcd/git2go/v33 v33.0.9-flux
+replace github.com/libgit2/git2go/v34 => github.com/fluxcd/git2go/v34 v34.0.0
+
+// Replace by named version before merging into main.
+replace github.com/fluxcd/pkg/git/libgit2 => github.com/fluxcd/pkg/git/libgit2 v0.0.0-20221007164102-c0aed7d985a4
 
 // This lets us use `go-billy/util.Walk()`, as this function hasn't been released
 // in a tagged version yet:
@@ -36,7 +39,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-containerregistry v0.11.0
-	github.com/libgit2/git2go/v33 v33.0.9
+	github.com/libgit2/git2go/v34 v34.0.0
 	github.com/onsi/gomega v1.20.2
 	github.com/otiai10/copy v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2Vvl
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
-github.com/fluxcd/git2go/v33 v33.0.9-flux h1:H6SCbrVx4a4KMewMSHW7lFqr5+Mm8HDhV1RD6n7J5tg=
-github.com/fluxcd/git2go/v33 v33.0.9-flux/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
+github.com/fluxcd/git2go/v34 v34.0.0 h1:08PEpdbsLO4sUTvFKuxmt6xBowaqObro9veChBWFwa8=
+github.com/fluxcd/git2go/v34 v34.0.0/go.mod h1:blVco2jDAw6YTXkErMMqzHLcAjKkwF0aWIRHBqiJkZ0=
 github.com/fluxcd/gitkit v0.6.0 h1:iNg5LTx6ePo+Pl0ZwqHTAkhbUHxGVSY3YCxCdw7VIFg=
 github.com/fluxcd/gitkit v0.6.0/go.mod h1:svOHuKi0fO9HoawdK4HfHAJJseZDHHjk7I3ihnCIqNo=
 github.com/fluxcd/image-reflector-controller/api v0.22.0 h1:IS3HbHdNTu0A/E6vdEkvIAo2fe0eMXHpEsDNUssYIIE=
@@ -159,8 +159,8 @@ github.com/fluxcd/pkg/apis/meta v0.16.0 h1:6Mj9rB0TtvCeTe3IlQDc1i2DH75Oosea9yUqS
 github.com/fluxcd/pkg/apis/meta v0.16.0/go.mod h1:GrOVzWXiu22XjLNgLLe2EBYhQPqZetes5SIADb4bmHE=
 github.com/fluxcd/pkg/git v0.6.1 h1:LC5k/5QBgDNoaDMb6ukmKNcxLih/Se09m1x5vLfUZb8=
 github.com/fluxcd/pkg/git v0.6.1/go.mod h1:O1YYuMUr5z8gHZrB3xBIMFyOdcCXG7kHUAuAqu6UkeA=
-github.com/fluxcd/pkg/git/libgit2 v0.1.1-0.20220908131225-538bbcd1fc66 h1:OqRl5sbUtsOOFkem1ajgmq/78sbXgiAAFeuswRvB/DE=
-github.com/fluxcd/pkg/git/libgit2 v0.1.1-0.20220908131225-538bbcd1fc66/go.mod h1:U0BrFOeONG/Au+LTlfc2UC6uRbLnWA8ulEj2liVLuTQ=
+github.com/fluxcd/pkg/git/libgit2 v0.0.0-20221007164102-c0aed7d985a4 h1:3XJ9N2EczpvWLG3suVE9jiD1bictAA6NHkSFRPg9vfs=
+github.com/fluxcd/pkg/git/libgit2 v0.0.0-20221007164102-c0aed7d985a4/go.mod h1:r9n6pcnCucx28Pw0WIiT9twcrUkhmNPTorKkT48sq8w=
 github.com/fluxcd/pkg/gittestserver v0.7.0 h1:PRVaEjeC/ePKTusB5Bx/ExM0P6bjroPdG6K2DO7YJUM=
 github.com/fluxcd/pkg/gittestserver v0.7.0/go.mod h1:WHqqZQfdePi5M/s1ONMTB4MigktqJhzAFJOZ0KTBw9Y=
 github.com/fluxcd/pkg/gitutil v0.2.0 h1:7vvXfq+Ur1/WXEejXY/b2haJ/2Uj5Et5v4V33l+ni1Q=

--- a/tests/fuzz/oss_fuzz_build.sh
+++ b/tests/fuzz/oss_fuzz_build.sh
@@ -16,7 +16,7 @@
 
 set -euxo pipefail
 
-LIBGIT2_TAG="${LIBGIT2_TAG:-v0.3.0}"
+LIBGIT2_TAG="${LIBGIT2_TAG:-v0.4.0}"
 GOPATH="${GOPATH:-/root/go}"
 GO_SRC="${GOPATH}/src"
 PROJECT_PATH="github.com/fluxcd/image-automation-controller"


### PR DESCRIPTION
The new version uses libgit2 1.5.0 and requires git2go/v34.