### PR TITLE
use gitrepo implementation for git ops

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/fluxcd/pkg/apis/acl v0.1.0
 	github.com/fluxcd/pkg/apis/meta v0.16.0
 	github.com/fluxcd/pkg/git v0.6.1
+	github.com/fluxcd/pkg/git/gogit v0.1.1-0.20220902101857-4d204a4a6fa4
 	github.com/fluxcd/pkg/git/libgit2 v0.1.1-0.20220908131225-538bbcd1fc66
 	github.com/fluxcd/pkg/gittestserver v0.7.0
 	github.com/fluxcd/pkg/runtime v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/fluxcd/pkg/apis/meta v0.16.0 h1:6Mj9rB0TtvCeTe3IlQDc1i2DH75Oosea9yUqS
 github.com/fluxcd/pkg/apis/meta v0.16.0/go.mod h1:GrOVzWXiu22XjLNgLLe2EBYhQPqZetes5SIADb4bmHE=
 github.com/fluxcd/pkg/git v0.6.1 h1:LC5k/5QBgDNoaDMb6ukmKNcxLih/Se09m1x5vLfUZb8=
 github.com/fluxcd/pkg/git v0.6.1/go.mod h1:O1YYuMUr5z8gHZrB3xBIMFyOdcCXG7kHUAuAqu6UkeA=
+github.com/fluxcd/pkg/git/gogit v0.1.1-0.20220902101857-4d204a4a6fa4 h1:qSo0LB4lSs+dNf7YLXsK+DRF8Dp6wdTSKHWccYHm+1Y=
+github.com/fluxcd/pkg/git/gogit v0.1.1-0.20220902101857-4d204a4a6fa4/go.mod h1:+0MYx3JTLAb62ZzBnoXU5RNnhjrD1knrQ3F/qzPh9Ds=
 github.com/fluxcd/pkg/git/libgit2 v0.0.0-20221007164102-c0aed7d985a4 h1:3XJ9N2EczpvWLG3suVE9jiD1bictAA6NHkSFRPg9vfs=
 github.com/fluxcd/pkg/git/libgit2 v0.0.0-20221007164102-c0aed7d985a4/go.mod h1:r9n6pcnCucx28Pw0WIiT9twcrUkhmNPTorKkT48sq8w=
 github.com/fluxcd/pkg/gittestserver v0.7.0 h1:PRVaEjeC/ePKTusB5Bx/ExM0P6bjroPdG6K2DO7YJUM=


### PR DESCRIPTION
Instead of using libgit2 for all Git operations, use the implementation specified in the GitRepository object.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>