### PR TITLE
gogit: Add new ForceGoGitImplementation FeatureGate

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -25,12 +25,23 @@ const (
 	// GitForcePushBranch enables the use of "force push" when push branches
 	// are configured.
 	GitForcePushBranch = "GitForcePushBranch"
+
+	// ForceGoGitImplementation ignores the value set for gitImplementation
+	// of a GitRepository object and ensures that go-git is used for all git operations.
+	//
+	// When enabled, libgit2 won't be initialized, nor will any git2go cgo
+	// code be called.
+	ForceGoGitImplementation = "ForceGoGitImplementation"
 )
 
 var features = map[string]bool{
 	// GitForcePushBranch
 	// opt-out from v0.27
 	GitForcePushBranch: true,
+
+	// ForceGoGitImplementation
+	// opt-out from v0.27
+	ForceGoGitImplementation: true,
 }
 
 // DefaultFeatureGates contains a list of all supported feature gates and

--- a/main.go
+++ b/main.go
@@ -163,9 +163,11 @@ func main() {
 	}
 	// +kubebuilder:scaffold:builder
 
-	if err = transport.InitManagedTransport(); err != nil {
-		setupLog.Error(err, "unable to initialize libgit2 managed transport")
-		os.Exit(1)
+	if gogitOnly, _ := features.Enabled(features.ForceGoGitImplementation); !gogitOnly {
+		if err = transport.InitManagedTransport(); err != nil {
+			setupLog.Error(err, "unable to initialize libgit2 managed transport")
+			os.Exit(1)
+		}
 	}
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
ForceGoGitImplementation ignores the value set for gitImplementation and ensures that go-git is used for all GitRepository objects. This can be used to confirm that Flux instances won't break if/when the libgit2 implementation was to be deprecated.

When enabled, libgit2 won't be initialized, nor will any git2go cgo code be called.