### PR TITLE
Add GitShallowClone feature

### DIFF
--- a/controllers/imageupdateautomation_controller.go
+++ b/controllers/imageupdateautomation_controller.go
@@ -298,6 +298,10 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 		opts.Branch = ref.Branch
 	}
 
+	if enabled, _ := r.features[features.GitShallowClone]; enabled {
+		opts.ShallowClone = true
+	}
+
 	// Use the git operations timeout for the repo.
 	cloneCtx, cancel := context.WithTimeout(ctx, origin.Spec.Timeout.Duration)
 	defer cancel()

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -32,6 +32,10 @@ const (
 	// When enabled, libgit2 won't be initialized, nor will any git2go cgo
 	// code be called.
 	ForceGoGitImplementation = "ForceGoGitImplementation"
+
+	// GitShallowClone enables the use of shallow clones when pulling source from
+	// Git repositories.
+	GitShallowClone = "GitShallowClone"
 )
 
 var features = map[string]bool{
@@ -42,6 +46,10 @@ var features = map[string]bool{
 	// ForceGoGitImplementation
 	// opt-out from v0.27
 	ForceGoGitImplementation: true,
+
+	// GitShallowClone
+	// opt-in from v0.28
+	GitShallowClone: false,
 }
 
 // DefaultFeatureGates contains a list of all supported feature gates and

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -48,8 +48,8 @@ var features = map[string]bool{
 	ForceGoGitImplementation: true,
 
 	// GitShallowClone
-	// opt-in from v0.28
-	GitShallowClone: false,
+	// opt-out from v0.28
+	GitShallowClone: true,
 }
 
 // DefaultFeatureGates contains a list of all supported feature gates and


### PR DESCRIPTION
This feature enables the use of shallow clones when pulling source from Git repositories.

#### How to test this
Use image: `ghcr.io/fluxcd/image-automation-controller:rc-0d41741b` and start the controller passing on: `--feature-gates=GitShallowClone=true`.

#### Outstanding work
- [x] Manual Tests
  - [x] GitHub push-branch
  - [x] Azure DevOps
  - [x] Azure DevOps push-branch
  - [x] BitBucket
- [x] Add some automated tests
- [x] Improve in-repo documentation
- [ ] Document new feature gate [in fluxcd.io](https://fluxcd.io/flux/components/image/options/) (Post IAC release)