### PR TITLE
Add feature gate `GitAllBranchReferences`

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,7 +33,6 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1beta2"
 
 	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta1"
-	"github.com/fluxcd/image-automation-controller/internal/features"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -60,12 +59,7 @@ func TestMain(m *testing.M) {
 	code := runTestsWithFeatures(m, nil)
 	if code != 0 {
 		fmt.Println("failed with default feature values")
-		os.Exit(code)
 	}
-
-	code = runTestsWithFeatures(m, map[string]bool{
-		features.GitShallowClone: true,
-	})
 
 	os.Exit(code)
 }

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -28,6 +28,9 @@ const (
 	// GitShallowClone enables the use of shallow clones when pulling source from
 	// Git repositories.
 	GitShallowClone = "GitShallowClone"
+	// GitAllBranchReferences enables the download of all branch head references
+	// when push branches are configured. When enabled fixes fluxcd/flux2#3384.
+	GitAllBranchReferences = "GitAllBranchReferences"
 )
 
 var features = map[string]bool{
@@ -38,6 +41,10 @@ var features = map[string]bool{
 	// GitShallowClone
 	// opt-out from v0.28
 	GitShallowClone: true,
+
+	// GitAllBranchReferences
+	// opt-out from v0.28
+	GitAllBranchReferences: true,
 }
 
 // DefaultFeatureGates contains a list of all supported feature gates and


### PR DESCRIPTION
The new feature gate enables users to toggle the download of all branch head references when push branches are configured. 

Tests were refactored to ensure that they are feature gate sensitive.

Fix fluxcd/flux2#3384.
Relates to fluxcd/pkg#433.