### PR TITLE
Disable caching of Secrets and ConfigMaps

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package features sets the feature gates that
-// source-controller supports, and their default
+// image-automation-controller supports, and their default
 // states.
 package features
 
@@ -31,6 +31,12 @@ const (
 	// GitAllBranchReferences enables the download of all branch head references
 	// when push branches are configured. When enabled fixes fluxcd/flux2#3384.
 	GitAllBranchReferences = "GitAllBranchReferences"
+	// CacheSecretsAndConfigMaps controls whether Secrets and ConfigMaps should
+	// be cached.
+	//
+	// When enabled, it will cache both object types, resulting in increased
+	// memory usage and cluster-wide RBAC permissions (list and watch).
+	CacheSecretsAndConfigMaps = "CacheSecretsAndConfigMaps"
 )
 
 var features = map[string]bool{
@@ -45,9 +51,13 @@ var features = map[string]bool{
 	// GitAllBranchReferences
 	// opt-out from v0.28
 	GitAllBranchReferences: true,
+
+	// CacheSecretsAndConfigMaps
+	// opt-in from v0.29
+	CacheSecretsAndConfigMaps: false,
 }
 
-// DefaultFeatureGates contains a list of all supported feature gates and
+// FeatureGates contains a list of all supported feature gates and
 // their default values.
 func FeatureGates() map[string]bool {
 	return features

--- a/main.go
+++ b/main.go
@@ -21,11 +21,13 @@ import (
 	"os"
 
 	flag "github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imagev1_reflect "github.com/fluxcd/image-reflector-controller/api/v1beta1"
 	"github.com/fluxcd/pkg/runtime/acl"
@@ -117,6 +119,16 @@ func main() {
 		watchNamespace = os.Getenv("RUNTIME_NAMESPACE")
 	}
 
+	var disableCacheFor []ctrlclient.Object
+	shouldCache, err := features.Enabled(features.CacheSecretsAndConfigMaps)
+	if err != nil {
+		setupLog.Error(err, "unable to check feature gate "+features.CacheSecretsAndConfigMaps)
+		os.Exit(1)
+	}
+	if !shouldCache {
+		disableCacheFor = append(disableCacheFor, &corev1.Secret{}, &corev1.ConfigMap{})
+	}
+
 	restConfig := client.GetConfigOrDie(clientOptions)
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                        scheme,
@@ -130,6 +142,7 @@ func main() {
 		RetryPeriod:                   &leaderElectionOptions.RetryPeriod,
 		LeaderElectionID:              fmt.Sprintf("%s-leader-election", controllerName),
 		Namespace:                     watchNamespace,
+		ClientDisableCacheFor:         disableCacheFor,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Disable caching of Secrets and ConfigMaps by default. Enable caching using feature gate:
```console
--feature-gates=CacheSecretsAndConfigMaps=true
```

Refer: https://github.com/fluxcd/flux2/issues/3426