### PR TITLE
Update Alpine to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN export CGO_LDFLAGS="-static -fuse-ld=lld" && \
 # Ensure that the binary was cross-compiled correctly to the target platform.
 RUN xx-verify --static /image-automation-controller
 
-FROM alpine:3.17
+FROM alpine:3.18
 
 ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates \


### PR DESCRIPTION
This change would be nice to get in because MUSL finally implemented TCP fallback in their DNS resolver.

alpinelinux.org/posts/Alpine-3.18.0-released.html