### PR TITLE
Set controller package name

### DIFF
--- a/internal/controller/controllers_fuzzer_test.go
+++ b/internal/controller/controllers_fuzzer_test.go
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/imageupdateautomation_controller.go
+++ b/internal/controller/imageupdateautomation_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"bytes"

--- a/internal/controller/imageupdateautomation_controller_test.go
+++ b/internal/controller/imageupdateautomation_controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"testing"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"fmt"

--- a/internal/controller/update_test.go
+++ b/internal/controller/update_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package controller
 
 import (
 	"bytes"

--- a/main.go
+++ b/main.go
@@ -188,12 +188,12 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	if err := (&controllers.ImageUpdateAutomationReconciler{
+	if err := (&controller.ImageUpdateAutomationReconciler{
 		Client:              mgr.GetClient(),
 		EventRecorder:       eventRecorder,
 		Metrics:             metricsH,
 		NoCrossNamespaceRef: aclOptions.NoCrossNamespaceRefs,
-	}).SetupWithManager(ctx, mgr, controllers.ImageUpdateAutomationReconcilerOptions{
+	}).SetupWithManager(ctx, mgr, controller.ImageUpdateAutomationReconcilerOptions{
 		RateLimiter: helper.GetRateLimiter(rateLimiterOptions),
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ImageUpdateAutomation")


### PR DESCRIPTION
Set package name in the files under internal/controller to have the base name of the directory.

This style is recommended by Go, and certain text editors/IDEs get confused when the names don't match.

Follow-up on 7cc9c9c5f4f37a2003d6d23fe8a692cd32884134