### PR TITLE
Align docs structure with other controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ manifests: controller-gen	## Generate manifests e.g. CRD, RBAC etc.
 	cd api; $(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role paths="./..." output:crd:artifacts:config="../config/crd/bases"
 
 api-docs: gen-crd-api-reference-docs	## Generate API reference documentation
-	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta1 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/image-automation.md
+	$(GEN_CRD_API_REFERENCE_DOCS) -api-dir=./api/v1beta1 -config=./hack/api-docs/config.json -template-dir=./hack/api-docs/template -out-file=./docs/api/v1beta1/image-automation.md
 
 tidy:	## Run go mod tidy
 	cd api; rm -f go.sum; go mod tidy -compat=1.20

--- a/docs/api/v1beta1/image-automation.md
+++ b/docs/api/v1beta1/image-automation.md
@@ -1,4 +1,4 @@
-<h1>Image update automation API reference</h1>
+<h1>Image update automation API reference v1beta1</h1>
 <p>Packages:</p>
 <ul class="simple">
 <li>

--- a/docs/spec/v1beta1/imageupdateautomations.md
+++ b/docs/spec/v1beta1/imageupdateautomations.md
@@ -1,6 +1,8 @@
 <!-- -*- fill-column: 100 -*- -->
 # Image Update Automations
 
+<!-- menuweight:50 -->
+
 The `ImageUpdateAutomation` type defines an automation process that will update a git repository,
 based on image policy objects in the same namespace.
 

--- a/hack/api-docs/template/pkg.tpl
+++ b/hack/api-docs/template/pkg.tpl
@@ -1,5 +1,10 @@
 {{ define "packages" }}
-    <h1>Image update automation API reference</h1>
+    <h1>Image update automation API reference
+        {{- with (index .packages 0) -}}
+            {{ with (index .GoPackages 0 ) -}}
+                {{ printf " %s" .Name -}}
+            {{ end -}}
+        {{ end }}</h1>
 
     {{ with .packages}}
         <p>Packages:</p>


### PR DESCRIPTION
In some controller we already support multiple API versions at the same time. In order to streamline the docs structure, the necessary changes to do the same in this repo are applied here as well.

refs fluxcd/website#1577
