### PR TITLE
Delete stale metrics on object delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fluxcd/pkg/git v0.12.4
 	github.com/fluxcd/pkg/git/gogit v0.12.1
 	github.com/fluxcd/pkg/gittestserver v0.8.5
-	github.com/fluxcd/pkg/runtime v0.41.0
+	github.com/fluxcd/pkg/runtime v0.42.0
 	github.com/fluxcd/pkg/ssh v0.8.1
 	github.com/fluxcd/source-controller/api v1.0.1
 	github.com/go-git/go-billy/v5 v5.4.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/fluxcd/pkg/git/gogit v0.12.1 h1:06jzHOTntYN5xCSQvyFXtLXdqoP8crLh7VYgt
 github.com/fluxcd/pkg/git/gogit v0.12.1/go.mod h1:Z4Ysp8VifKTvWpjJMKncJsgb2iBqHuIeK80VGjlU41Y=
 github.com/fluxcd/pkg/gittestserver v0.8.5 h1:EGqDF4240xPRgW1FFrQAs0Du7fZb8OGXC5qKDIqyXD8=
 github.com/fluxcd/pkg/gittestserver v0.8.5/go.mod h1:SyGEh+OBzFpdlTWWqv3XBkiLB42Iu+mijfIQ4hPlEZQ=
-github.com/fluxcd/pkg/runtime v0.41.0 h1:hjWUwVRCKDuGEUhovWrygt/6PRry4p278yKuJNgTfv8=
-github.com/fluxcd/pkg/runtime v0.41.0/go.mod h1:1GN+nxoQ7LmSsLJwjH8JW8pA27tBSO+KLH43HpywCDM=
+github.com/fluxcd/pkg/runtime v0.42.0 h1:a5DQ/f90YjoHBmiXZUpnp4bDSLORjInbmqP7K11L4uY=
+github.com/fluxcd/pkg/runtime v0.42.0/go.mod h1:p6A3xWVV8cKLLQW0N90GehKgGMMmbNYv+OSJ/0qB0vg=
 github.com/fluxcd/pkg/ssh v0.8.1 h1:v35y7Ks/+ABWce8RcnrC7psVIhf3EdCUNFJi5+tYOps=
 github.com/fluxcd/pkg/ssh v0.8.1/go.mod h1:M1ouDXuDG+QuhGB4JYEjCNCykNytLJGDhwKn9y4DEOE=
 github.com/fluxcd/pkg/version v0.2.2 h1:ZpVXECeLA5hIQMft11iLp6gN3cKcz6UNuVTQPw/bRdI=

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	feathelper "github.com/fluxcd/pkg/runtime/features"
 	"github.com/fluxcd/pkg/runtime/leaderelection"
 	"github.com/fluxcd/pkg/runtime/logger"
+	"github.com/fluxcd/pkg/runtime/metrics"
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -184,7 +185,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	metricsH := helper.MustMakeMetrics(mgr)
+	metricsH := helper.NewMetrics(mgr, metrics.MustMakeRecorder(), imagev1.ImageUpdateAutomationFinalizer)
 
 	ctx := ctrl.SetupSignalHandler()
 


### PR DESCRIPTION
~Depends on https://github.com/fluxcd/pkg/pull/612~

The metrics helper now accepts owned finalizers to determine if an object is no longer managed by the controller and is being deleted, and deletes the metrics associated with the object.

Call the metrics recording defer function in reconciler early to be able to record the object in deleting state.

Before this change, the following metrics continued to be exported even after the associated object is deleted for image update automation:

```
# HELP gotk_reconcile_condition The current condition status of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_condition gauge
gotk_reconcile_condition{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",status="False",type="Ready"} 1
gotk_reconcile_condition{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",status="True",type="Ready"} 0
gotk_reconcile_condition{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",status="Unknown",type="Ready"} 0
# HELP gotk_reconcile_duration_seconds The duration in seconds of a GitOps Toolkit resource reconciliation.
# TYPE gotk_reconcile_duration_seconds histogram
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="0.01"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="0.038363583488692544"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="0.1471764538093883"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="0.5646216173286169"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="2.166090855590701"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="8.309900738254731"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="31.879757075478317"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="122.30217221643493"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="469.19495946736544"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="1799.9999999999986"} 1
gotk_reconcile_duration_seconds_bucket{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default",le="+Inf"} 1
gotk_reconcile_duration_seconds_sum{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default"} 0.009209323
gotk_reconcile_duration_seconds_count{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default"} 1
# HELP gotk_suspend_status The current suspend status of a GitOps Toolkit resource.
# TYPE gotk_suspend_status gauge
gotk_suspend_status{kind="ImageUpdateAutomation",name="test-update-auto",namespace="default"} 0
```

With this change, they get deleted once the associated object is deleted.

Also, the metrics helper no longer exports `ConditionDelete` for readiness metrics.