### PR TITLE
Fix links in API docs

### DIFF
--- a/docs/spec/v1beta1/imageupdateautomations.md
+++ b/docs/spec/v1beta1/imageupdateautomations.md
@@ -692,7 +692,7 @@ spec:
 ```
 
 [image-auto-guide]: https://fluxcd.io/flux/guides/image-update/#configure-image-update-for-custom-resources
-[git-repo-ref]: https://fluxcd.io/flux/components/source/gitrepositories/#specification
+[git-repo-ref]: https://fluxcd.io/flux/components/source/gitrepositories/#writing-a-gitrepository-spec
 [durations]: https://godoc.org/time#ParseDuration
-[source-docs]: https://fluxcd.io/flux/components/source/gitrepositories/#git-implementation
+[source-docs]: https://fluxcd.io/flux/components/source/api/v1beta2/#source.toolkit.fluxcd.io/v1beta2.GitRepositorySpec
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
* https://github.com/fluxcd/website/pull/1621

Unsure if maybe we should leave the `https://fluxcd.io` base domain intact here, so these docs are usable from the repo as a reference too. (Edit: I did wind up putting the base URL back in. I don't know if we're doing that consistently, but no need to break it here.)