### PR TITLE
Fix push branch reporting when is equal to checkout branch

### DIFF
--- a/internal/controller/imageupdateautomation_controller.go
+++ b/internal/controller/imageupdateautomation_controller.go
@@ -422,7 +422,7 @@ func (r *ImageUpdateAutomationReconciler) Reconcile(ctx context.Context, req ctr
 				return failWithError(err)
 			}
 			log.Info("pushed commit to origin", "revision", rev, "branch", pushBranch)
-			statusMessage.WriteString(fmt.Sprintf("commited and pushed commit '%s' to branch '%s'", rev, pushBranch))
+			statusMessage.WriteString(fmt.Sprintf("committed and pushed commit '%s' to branch '%s'", rev, pushBranch))
 		}
 
 		if gitSpec.Push != nil && gitSpec.Push.Refspec != "" {


### PR DESCRIPTION
Fix the push branch reported in the logs and status if `.spec.git.push.branch==.spec.git.checkout.branch`.

Fixes #580 