### PR TITLE
Add support to limit applied policies in automation by specifying a selector

### DIFF
--- a/api/v1beta1/imageupdateautomation_types.go
+++ b/api/v1beta1/imageupdateautomation_types.go
@@ -49,6 +49,11 @@ type ImageUpdateAutomationSpec struct {
 	// +required
 	Interval metav1.Duration `json:"interval"`
 
+	// PolicySelector allows to filter applied policies based on labels.
+	// By default includes all policies in namespace
+	// +optional
+	PolicySelector *metav1.LabelSelector `json:"policySelector"`
+
 	// Update gives the specification for how to update the files in
 	// the repository. This can be left empty, to use the default
 	// value.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -188,6 +188,11 @@ func (in *ImageUpdateAutomationSpec) DeepCopyInto(out *ImageUpdateAutomationSpec
 		(*in).DeepCopyInto(*out)
 	}
 	out.Interval = in.Interval
+	if in.PolicySelector != nil {
+		in, out := &in.PolicySelector, &out.PolicySelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Update != nil {
 		in, out := &in.Update, &out.Update
 		*out = new(UpdateStrategy)

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -158,6 +158,52 @@ spec:
                   run should be attempted.
                 pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
                 type: string
+              policySelector:
+                description: PolicySelector allows to filter applied policies based
+                  on labels. By default includes all policies in namespace
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
               sourceRef:
                 description: SourceRef refers to the resource giving access details
                   to a git repository.


### PR DESCRIPTION
Hello! I want to automate external image updates to my repository, each image to its separate branch — something like Dependabot does. But since the `ImageUpdateAutomation` resource doesn't have a direct relation to `ImagePolicy` resources except for being in the same namespace, I would have to create a separate namespace for each pair of `ImagePolicy` and `ImageUpdateAutomation` otherwise updates would be merged in 1 branch.

The problem was previously discussed in #499 and fluxcd/flux2#107

The solution to the problem would be to have some kind of relation between `ImageUpdateAutomation` and `ImagePolicy`. I see 2 ways how  `ImageUpdateAutomation` resource can be improved to support such a use case:

1.  Have a list of policies and reference them explicitly
```yaml
apiVersion: image.fluxcd.io/v1alpha1
kind: ImageUpdateAutomation
metadata:
  name: update-teleport
spec:
  policies:
    - name: teleport
    - name: teleport-helper
  ...
```
2. Have a policy selector and filter policies by it
```yaml
apiVersion: image.fluxcd.io/v1alpha1
kind: ImageUpdateAutomation
metadata:
  name: update-teleport
spec:
  policySelector:
    matchLabels:
      app.kubernetes.io/component: teleport
      app.kubernetes.io/instance: teleport
  ...
```

In this PR I implemented the second option because it's more flexible, covers more use cases (you can batch updates however you like), and you can also imitate the first option with `kubernetes.io/metadata.name` label