### PR TITLE
adding tests for accept function

### DIFF
--- a/pkg/update/filter_test.go
+++ b/pkg/update/filter_test.go
@@ -1,0 +1,55 @@
+package update
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestSetAllCallbackAccept(t *testing.T) {
+	tests := []struct {
+		name          string
+		object        *yaml.RNode
+		settersSchema *spec.Schema
+		expectedError bool
+	}{
+		{
+			name: "Accept - Scalar Node",
+			object: yaml.NewRNode(&yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: "test",
+			}),
+			settersSchema: &spec.Schema{},
+			expectedError: false,
+		},
+		{
+			name: "Accept - Scalar Node - Error",
+			object: yaml.NewRNode(&yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: "test",
+			}),
+			settersSchema: nil,
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			callbackInstance := SetAllCallback{
+				SettersSchema: test.settersSchema,
+				Trace:         logr.Discard(),
+			}
+
+			err := accept(&callbackInstance, test.object, "", test.settersSchema)
+			g := NewWithT(t)
+			if test.expectedError {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Tests for Accept - Scalar Node:**

Description: Tests the accept function when provided with a scalar node and valid setter schema.
The function should not return an error (assert.NoError).
The expected error value should be false (assert.Equal).

**Tests for Accept - Scalar Node - Error:**

Description: Tests the accept function when provided with a scalar node, with invalid setter schema.
The function should not return an error (assert.NoError).
The expected error value should be true (assert.Equal).