### PR TITLE
Add predicates for GitRepo and ImagePolicy watches

### DIFF
--- a/internal/controller/imageupdateautomation_controller.go
+++ b/internal/controller/imageupdateautomation_controller.go
@@ -478,8 +478,16 @@ func (r *ImageUpdateAutomationReconciler) SetupWithManager(ctx context.Context, 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&imagev1.ImageUpdateAutomation{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, predicates.ReconcileRequestedPredicate{}))).
-		Watches(&sourcev1.GitRepository{}, handler.EnqueueRequestsFromMapFunc(r.automationsForGitRepo)).
-		Watches(&imagev1_reflect.ImagePolicy{}, handler.EnqueueRequestsFromMapFunc(r.automationsForImagePolicy)).
+		Watches(
+			&sourcev1.GitRepository{},
+			handler.EnqueueRequestsFromMapFunc(r.automationsForGitRepo),
+			builder.WithPredicates(sourceConfigChangePredicate{}),
+		).
+		Watches(
+			&imagev1_reflect.ImagePolicy{},
+			handler.EnqueueRequestsFromMapFunc(r.automationsForImagePolicy),
+			builder.WithPredicates(latestImageChangePredicate{}),
+		).
 		WithOptions(controller.Options{
 			RateLimiter: opts.RateLimiter,
 		}).

--- a/internal/controller/predicate.go
+++ b/internal/controller/predicate.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	imagev1_reflect "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+)
+
+// latestImageChangePredicate implements a predicate for latest image change.
+// This can be used to filter events from ImagePolicies for change in the latest
+// image.
+type latestImageChangePredicate struct {
+	predicate.Funcs
+}
+
+func (latestImageChangePredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (latestImageChangePredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (latestImageChangePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	oldSource, ok := e.ObjectOld.(*imagev1_reflect.ImagePolicy)
+	if !ok {
+		return false
+	}
+
+	newSource, ok := e.ObjectNew.(*imagev1_reflect.ImagePolicy)
+	if !ok {
+		return false
+	}
+
+	if oldSource.Status.LatestImage != newSource.Status.LatestImage {
+		return true
+	}
+
+	return false
+}
+
+// sourceConfigChangePredicate implements a predicate for source configuration
+// change. This can be used to filter events from source objects for change in
+// source configuration.
+type sourceConfigChangePredicate struct {
+	predicate.Funcs
+}
+
+func (sourceConfigChangePredicate) Create(e event.CreateEvent) bool {
+	return false
+}
+
+func (sourceConfigChangePredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func (sourceConfigChangePredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil || e.ObjectNew == nil {
+		return false
+	}
+
+	return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+}

--- a/internal/controller/predicate_test.go
+++ b/internal/controller/predicate_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	imagev1_reflect "github.com/fluxcd/image-reflector-controller/api/v1beta2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+)
+
+func Test_latestImageChangePredicate_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		beforeFunc func(oldObj, newObj *imagev1_reflect.ImagePolicy)
+		want       bool
+	}{
+		{
+			name: "no latest image",
+			beforeFunc: func(oldObj, newObj *imagev1_reflect.ImagePolicy) {
+				oldObj.Status.LatestImage = ""
+				newObj.Status.LatestImage = ""
+			},
+			want: false,
+		},
+		{
+			name: "new image, no old image",
+			beforeFunc: func(oldObj, newObj *imagev1_reflect.ImagePolicy) {
+				oldObj.Status.LatestImage = ""
+				newObj.Status.LatestImage = "foo"
+			},
+			want: true,
+		},
+		{
+			name: "different old and new image",
+			beforeFunc: func(oldObj, newObj *imagev1_reflect.ImagePolicy) {
+				oldObj.Status.LatestImage = "bar"
+				newObj.Status.LatestImage = "foo"
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			oldObj := &imagev1_reflect.ImagePolicy{}
+			newObj := oldObj.DeepCopy()
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(oldObj, newObj)
+			}
+			e := event.UpdateEvent{
+				ObjectOld: oldObj,
+				ObjectNew: newObj,
+			}
+			p := latestImageChangePredicate{}
+			g.Expect(p.Update(e)).To(Equal(tt.want))
+		})
+	}
+}
+
+func Test_sourceConfigChangePredicate_Update(t *testing.T) {
+	tests := []struct {
+		name       string
+		beforeFunc func(oldObj, newObj *sourcev1.GitRepository)
+		want       bool
+	}{
+		{
+			name: "no generation change, same config",
+			beforeFunc: func(oldObj, newObj *sourcev1.GitRepository) {
+				oldObj.Generation = 0
+				newObj.Generation = 0
+			},
+			want: false,
+		},
+		{
+			name: "new generation, config change",
+			beforeFunc: func(oldObj, newObj *sourcev1.GitRepository) {
+				oldObj.Generation = 1
+				newObj.Generation = 2
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			oldObj := &sourcev1.GitRepository{}
+			newObj := oldObj.DeepCopy()
+			if tt.beforeFunc != nil {
+				tt.beforeFunc(oldObj, newObj)
+			}
+			e := event.UpdateEvent{
+				ObjectOld: oldObj,
+				ObjectNew: newObj,
+			}
+			p := sourceConfigChangePredicate{}
+			g.Expect(p.Update(e)).To(Equal(tt.want))
+		})
+	}
+
+}


### PR DESCRIPTION
While working on the refactoring the controller, I noticed that it was getting triggered more than expected. This change is similar to a corresponding change in image-reflector-controller ImagePolicyReconciler, refer https://github.com/fluxcd/image-reflector-controller/pull/334, to reduce unnecessary reconciliations. Adding this to the main branch separately from the refactor to reduce introducing new behavior in the refactor branch.

ImageUpdateAutomationReconciler watches GitRepository and ImagePolicy kinds for every event. This leads to unnecessary extra reconciliations at times. For example when the controller starts with existing resources, the same ImageUpdateAutomation object gets reconciled at least twice, once due to the watch on ImageUpdateAutomation at startup and again due to the watches on GitRepository and ImagePolicy for create event, as they get registered in the cache.

Add predicates to filter the ImagePolicy watch to only allow events for latest image update, and GitRepository watch to only allow events for change in the source configuration.

For example, previously when the controller started with existing resources, following multiple reconciliations could be seen:
```console
2024-02-27T02:00:08.759+0530    INFO    no changes made in working directory; no commit {"controller": "imageupdateautomation", "controllerGroup": "image.toolkit.fluxcd.io", "controllerKind": "ImageUpdateAutomation", "ImageUpdateAutomation": {"name":"test-update-auto","namespace":"default"}, "namespace": "default", "name": "test-update-auto", "reconcileID": "84600cf1-8461-4636-96c7-b0f5fe464506"}
2024-02-27T02:00:08.832+0530    INFO    no changes made in working directory; no commit {"controller": "imageupdateautomation", "controllerGroup": "image.toolkit.fluxcd.io", "controllerKind": "ImageUpdateAutomation", "ImageUpdateAutomation": {"name":"test-update-auto","namespace":"default"}, "namespace": "default", "name": "test-update-auto", "reconcileID": "ff70cb0f-ef70-41d2-b036-3008fc5a26c4"}
```
With the new predicates:
```console
2024-02-27T03:25:27.862+0530    INFO    no changes made in working directory; no commit {"controller": "imageupdateautomation", "controllerGroup": "image.toolkit.fluxcd.io", "controllerKind": "ImageUpdateAutomation", "ImageUpdateAutomation": {"name":"test-update-auto","namespace":"default"}, "namespace": "default", "name": "test-update-auto", "reconcileID": "86861ba9-5466-42a8-8ada-c0fb1b307f5e"}
```

Also adds a test to make sure that ImageUpdateAutomation continues to get triggered on updates to ImagePolicy and GitRepository.