### PR TITLE
Introduce ResultV2 for update results

### DIFF
--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -92,3 +92,80 @@ func TestUpdateResults(t *testing.T) {
 		},
 	}))
 }
+
+func TestResultV2(t *testing.T) {
+	g := NewWithT(t)
+
+	var result ResultV2
+	objectNames := []ObjectIdentifier{
+		{yaml.ResourceIdentifier{
+			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "foo"},
+		}},
+		{yaml.ResourceIdentifier{
+			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "bar"},
+		}},
+	}
+
+	result.AddChange("foo.yaml", objectNames[0], Change{
+		OldValue: "aaa",
+		NewValue: "bbb",
+		Setter:   "foo-ns:policy:name",
+	})
+	result.AddChange("bar.yaml", objectNames[1], Change{
+		OldValue: "cccc:v1.0",
+		NewValue: "cccc:v1.2",
+		Setter:   "foo-ns:policy",
+	})
+
+	result = ResultV2{
+		FileChanges: map[string]ObjectChanges{
+			"foo.yaml": {
+				objectNames[0]: []Change{
+					{
+						OldValue: "aaa",
+						NewValue: "bbb",
+						Setter:   "foo-ns:policy:name",
+					},
+				},
+			},
+			"bar.yaml": {
+				objectNames[1]: []Change{
+					{
+						OldValue: "cccc:v1.0",
+						NewValue: "cccc:v1.2",
+						Setter:   "foo-ns:policy",
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(result.Changes()).To(ContainElements([]Change{
+		{
+			OldValue: "aaa",
+			NewValue: "bbb",
+			Setter:   "foo-ns:policy:name",
+		},
+		{
+			OldValue: "cccc:v1.0",
+			NewValue: "cccc:v1.2",
+			Setter:   "foo-ns:policy",
+		},
+	}))
+	g.Expect(result.Objects()).To(Equal(ObjectChanges{
+		objectNames[0]: []Change{
+			{
+				OldValue: "aaa",
+				NewValue: "bbb",
+				Setter:   "foo-ns:policy:name",
+			},
+		},
+		objectNames[1]: []Change{
+			{
+				OldValue: "cccc:v1.0",
+				NewValue: "cccc:v1.2",
+				Setter:   "foo-ns:policy",
+			},
+		},
+	}))
+}


### PR DESCRIPTION
`ResultV2` update result contains `Result` (original), which provides information in terms of files, objects and images, and also includes file changes which provides information in terms of files, objects and changes. The changes contain the old value, new value and the setter that was involved in the update.
`ResultV2` can be used to obtain detailed information about updates in terms of the previous value and the new value, which could be beneficial in commit messages to summarize the granular changes.

`ResultV2` is introduced in a backwards compatible way. The existing behavior is not changed. It will only be used by the refactored controller in the future. Introducing it in the main branch to keep the refactored controller changes small.

Related to https://github.com/fluxcd/image-automation-controller/issues/437 