### PR TITLE
Deprecate v1beta1 API

### DIFF
--- a/api/v1beta1/imageupdateautomation_types.go
+++ b/api/v1beta1/imageupdateautomation_types.go
@@ -135,6 +135,7 @@ func SetImageUpdateAutomationReadiness(auto *ImageUpdateAutomation, status metav
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:deprecatedversion:warning="v1beta1 ImageUpdateAutomation is deprecated, upgrade to v1beta2"
 //+kubebuilder:printcolumn:name="Last run",type=string,JSONPath=`.status.lastAutomationRunTime`
 
 // ImageUpdateAutomation is the Schema for the imageupdateautomations API

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -18,6 +18,8 @@ spec:
     - jsonPath: .status.lastAutomationRunTime
       name: Last run
       type: string
+    deprecated: true
+    deprecationWarning: v1beta1 ImageUpdateAutomation is deprecated, upgrade to v1beta2
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
Add a deprecation note to upgrade to v1beta2 API.

Part of https://github.com/fluxcd/flux2/issues/4712