### PR TITLE
Adding assertions for AddChange test scenario for ResultV2 Test

### DIFF
--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -117,6 +117,28 @@ func TestResultV2(t *testing.T) {
 		Setter:   "foo-ns:policy",
 	})
 
+	expectedFileChanges := map[string]ObjectChanges{
+		"foo.yaml": {
+			objectNames[0]: []Change{
+				{
+					OldValue: "aaa",
+					NewValue: "bbb",
+					Setter:   "foo-ns:policy:name",
+				},
+			},
+		},
+		"bar.yaml": {
+			objectNames[1]: []Change{
+				{
+					OldValue: "cccc:v1.0",
+					NewValue: "cccc:v1.2",
+					Setter:   "foo-ns:policy",
+				},
+			},
+		},
+	}
+	g.Expect(result.FileChanges).To(Equal(expectedFileChanges))
+
 	result = ResultV2{
 		FileChanges: map[string]ObjectChanges{
 			"foo.yaml": {


### PR DESCRIPTION
The updated test accounts for much needed assertions for AddChange scenario in Result V2 test:

This code snippet initializes an **expectedFileChanges variable**, which is containing the expected changes. Each file is associated with a set of object changes represented by ObjectChanges. Within each file's changes, specific objects are associated with an array of Change structs, where each struct represents a change in values. The g.Expect(result.FileChanges) statement asserts that the FileChanges field of the result variable matches the expected changes defined.