### PR TITLE
[RFC-007] Implement GitHub app authentication for git repositories in IAC

### DIFF
--- a/docs/spec/v1beta2/imageupdateautomations.md
+++ b/docs/spec/v1beta2/imageupdateautomations.md
@@ -257,6 +257,13 @@ patches:
               azure.workload.identity/use: "true"
 ```
 
+##### GitHub
+
+If the provider is set to `github`, make sure the GitHub App is registered and
+installed with the necessary permissions and the github app secret is configured
+as described
+[here](https://fluxcd.io/flux/components/source/gitrepositories/#github).
+
 ### Git specification
 
 `.spec.git` is a required field to specify Git configurations related to source


### PR DESCRIPTION
- Controller change to use the GitHub authentication information specified in `gitrepository.spec.secretRef` to create the auth options to authenticate to git repositories when the `gitrepository.spec.provider` field is set to `github`,
- Tests for new `github` provider field in IAC
- Updated docs to use GitHub Apps for authentication in image-automation-controller.