### PR TITLE
Fix `knownhosts key mismatch` regression bug in go-git

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.24.0
 
 replace github.com/fluxcd/image-automation-controller/api => ./api
 
+// Pin go-git to fix SSH knownhosts key mismatch regression bug
+// xref: https://github.com/fluxcd/flux2/issues/5385
+replace github.com/go-git/go-git/v5 => github.com/go-git/go-git/v5 v5.16.3-0.20250610123634-8ac015a75d81
+
 // Pin kustomize to v5.6.0
 replace (
 	sigs.k8s.io/kustomize/api => sigs.k8s.io/kustomize/api v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -154,8 +154,8 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.16.2 h1:fT6ZIOjE5iEnkzKyxTHK1W4HGAsPhqEqiSAssSO77hM=
-github.com/go-git/go-git/v5 v5.16.2/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.3-0.20250610123634-8ac015a75d81 h1:Kx1vl1xNqB48sOGH4boH1hLJiUAvda5rPaACGyOg4qo=
+github.com/go-git/go-git/v5 v5.16.3-0.20250610123634-8ac015a75d81/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=


### PR DESCRIPTION
This PR pins go-git to a version where the following changes have been reverted:
- https://github.com/go-git/go-git/pull/1482
- https://github.com/go-git/go-git/pull/1515

The above changes broken the known hosts verification of GitLab servers using `ssh-rsa`, `ssh-ed25519` and any other host key algo besides `ecdsa-sha2-nistp256`.
 
Refs:
- https://github.com/fluxcd/source-controller/pull/1828
- https://github.com/fluxcd/flux2/issues/5385
- https://github.com/go-git/go-git/issues/1551

Release candidate images: