### PR TITLE
Add shortNames aliases for ImageUpdateAutomation CRD

### DIFF
--- a/api/v1beta2/imageupdateautomation_types.go
+++ b/api/v1beta2/imageupdateautomation_types.go
@@ -133,6 +133,7 @@ type ObservedPolicies map[string]ImageRef
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Last run",type=string,JSONPath=`.status.lastAutomationRunTime`
+//+kubebuilder:resource:shortName=iua;imgupd;imgauto
 
 // ImageUpdateAutomation is the Schema for the imageupdateautomations API
 type ImageUpdateAutomation struct {

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -11,6 +11,10 @@ spec:
     kind: ImageUpdateAutomation
     listKind: ImageUpdateAutomationList
     plural: imageupdateautomations
+    shortNames:
+    - iua
+    - imgupd
+    - imgauto
     singular: imageupdateautomation
   scope: Namespaced
   versions:


### PR DESCRIPTION
## Summary

This PR adds shortNames aliases for ImageUpdateAutomation CRD to enable shorter kubectl commands as requested in https://github.com/fluxcd/flux2/issues/5411 .

## Changes

- Add multiple aliases for ImageUpdateAutomation: `imgupd`, `imageupdate`, `imgauto`, `imageauto`

The aliases follow Flux ecosystem naming conventions using the `img` prefix, consistent with standard Docker/Kubernetes terminology and aligned with other Flux CRD shortNames (e.g., `gitrepo`, `helmrepo`, `hr`, `ks`). Additional aliases provide users with more flexibility in choosing their preferred shorthand.

The specific shortNames were suggested by @matheuscscp in https://github.com/fluxcd/image-reflector-controller/pull/785#issuecomment-2987656652.

## Verification

After applying the updated CRDs, the aliases are correctly registered:

```
$ kubectl api-resources | grep -E "imageupdateautomation"
imageupdateautomations              imgupd,imageupdate,imgauto,imageauto   image.toolkit.fluxcd.io/v1beta2          true         ImageUpdateAutomation
```

Users can now use shorter commands with multiple options:
- `kubectl get imgupd` / `kubectl get imageupdate` / `kubectl get imgauto` / `kubectl get imageauto` instead of `kubectl get imageupdateautomations`