### PR TITLE
Add deprecation handling for .Updated template field

### DIFF
--- a/api/v1beta2/condition_types.go
+++ b/api/v1beta2/condition_types.go
@@ -36,4 +36,7 @@ const (
 
 	// InvalidPolicySelectorReason represents an invalid policy selector.
 	InvalidPolicySelectorReason string = "InvalidPolicySelector"
+
+	// RemovedTemplateFieldReason represents usage of removed template field.
+	RemovedTemplateFieldReason string = "RemovedTemplateField"
 )

--- a/api/v1beta2/git.go
+++ b/api/v1beta2/git.go
@@ -65,6 +65,7 @@ type CommitSpec struct {
 	SigningKey *SigningKey `json:"signingKey,omitempty"`
 	// MessageTemplate provides a template for the commit message,
 	// into which will be interpolated the details of the change made.
+	// Note: The `Updated` template field has been removed. Use `Changed` instead.
 	// +optional
 	MessageTemplate string `json:"messageTemplate,omitempty"`
 

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -440,6 +440,7 @@ spec:
                         description: |-
                           MessageTemplate provides a template for the commit message,
                           into which will be interpolated the details of the change made.
+                          Note: The `Updated` template field has been removed. Use `Changed` instead.
                         type: string
                       messageTemplateValues:
                         additionalProperties:

--- a/docs/api/v1beta2/image-automation.md
+++ b/docs/api/v1beta2/image-automation.md
@@ -67,7 +67,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>MessageTemplate provides a template for the commit message,
-into which will be interpolated the details of the change made.</p>
+into which will be interpolated the details of the change made.
+Note: The <code>Updated</code> template field has been removed. Use <code>Changed</code> instead.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/v1beta2/imageupdateautomations.md
+++ b/docs/spec/v1beta2/imageupdateautomations.md
@@ -374,12 +374,11 @@ spec:
         Automated image update by Flux
 ```
 
-**Deprecation Note:** The `Updated` template data available in v1beta1 API is
-deprecated. `Changed` template data is recommended for template data, as it
-accommodates for all the updates, including partial updates to just the image
-name or the tag, not just full image with name and tag update. The old templates
-will continue to work in v1beta2 API as `Updated` has not been removed yet. In
-the next API version, `Updated` may be removed.
+**Removal Note:** The `Updated` template data has been removed from the API.
+Use `Changed` template data instead, as it accommodates for all the updates,
+including partial updates to just the image name or the tag, not just full image
+with name and tag update. Templates using `Updated` will result in an error and
+the ImageUpdateAutomation will be marked as Stalled.
 
 The message template also has access to the data related to the changes made by
 the automation. The template is a [Go text template][go-text-template]. The data

--- a/docs/spec/v1beta2/imageupdateautomations.md
+++ b/docs/spec/v1beta2/imageupdateautomations.md
@@ -380,6 +380,7 @@ including partial updates to just the image name or the tag, not just full image
 with name and tag update. Templates using `Updated` will result in an error and
 the ImageUpdateAutomation will be marked as Stalled.
 
+
 The message template also has access to the data related to the changes made by
 the automation. The template is a [Go text template][go-text-template]. The data
 available to the template have the following structure (not reproduced
@@ -392,14 +393,14 @@ type TemplateData struct {
 	AutomationObject struct {
 	  Name, Namespace string
 	}
-	Changed update.ResultV2
+	Changed update.Result
 	Values map[string]string
 }
 
-// ResultV2 contains the file changes made during the update. It contains
+// Result contains the file changes made during the update. It contains
 // details about the exact changes made to the files and the objects in them. It
 // has a nested structure file->objects->changes.
-type ResultV2 struct {
+type Result struct {
 	FileChanges map[string]ObjectChanges
 }
 
@@ -426,10 +427,10 @@ over the changed objects and changes:
 
 ```go
 // Changes returns all the changes that were made in at least one update.
-func (r ResultV2) Changes() []Change
+func (r Result) Changes() []Change
 
 // Objects returns ObjectChanges, regardless of which file they appear in.
-func (r ResultV2) Objects() ObjectChanges
+func (r Result) Objects() ObjectChanges
 ```
 
 Example of using the methods in a template:

--- a/internal/controller/imageupdateautomation_controller_test.go
+++ b/internal/controller/imageupdateautomation_controller_test.go
@@ -71,12 +71,12 @@ const (
 Automation: {{ .AutomationObject }}
 
 Files:
-{{ range $filename, $_ := .Changed.ImageResult.Files -}}
+{{ range $filename, $_ := .Changed.FileChanges -}}
 - {{ $filename }}
 {{ end -}}
 
 Objects:
-{{ range $resource, $_ := .Changed.ImageResult.Objects -}}
+{{ range $resource, $_ := .Changed.Objects -}}
 {{ if eq $resource.Kind "Deployment" -}}
 - {{ $resource.Kind | lower }} {{ $resource.Name | lower }}
 {{ else -}}
@@ -85,8 +85,10 @@ Objects:
 {{ end -}}
 
 Images:
-{{ range .Changed.ImageResult.Images -}}
-- {{.}} ({{.Policy.Name}})
+{{ range .Changed.Changes -}}
+{{ if .Setter -}}
+- {{.NewValue}} ({{.Setter}})
+{{ end -}}
 {{ end -}}
 `
 	testCommitMessageFmt = `Commit summary
@@ -98,7 +100,7 @@ Files:
 Objects:
 - deployment test
 Images:
-- helloworld:v1.0.0 (%s)
+- helloworld:v1.0.0 (%s:%s)
 `
 )
 
@@ -727,7 +729,7 @@ func TestImageUpdateAutomationReconciler_commitMessage(t *testing.T) {
 			name:     "template with update Result",
 			template: testCommitTemplate,
 			wantCommitMsg: func(policyName, policyNS string) string {
-				return fmt.Sprintf(testCommitMessageFmt, policyNS, policyName)
+				return fmt.Sprintf(testCommitMessageFmt, policyNS, policyNS, policyName)
 			},
 		},
 		{
@@ -841,11 +843,8 @@ Automation: %s/update-test
 	}
 }
 
-// TestImageUpdateAutomationReconciler_removedTemplateField tests removed .Updated template field usage.
+// TestImageUpdateAutomationReconciler_removedTemplateField tests removed template field usage (.Updated and .Changed.ImageResult).
 func TestImageUpdateAutomationReconciler_removedTemplateField(t *testing.T) {
-	g := NewWithT(t)
-	ctx := context.TODO()
-
 	policySpec := imagev1_reflect.ImagePolicySpec{
 		ImageRepositoryRef: meta.NamespacedObjectReference{
 			Name: "not-expected-to-exist",
@@ -859,7 +858,14 @@ func TestImageUpdateAutomationReconciler_removedTemplateField(t *testing.T) {
 	fixture := "testdata/appconfig"
 	latest := "helloworld:v1.0.0"
 
-	removedTemplate := `Commit summary
+	testCases := []struct {
+		name           string
+		template       string
+		expectedErrMsg string
+	}{
+		{
+			name: ".Updated field",
+			template: `Commit summary
 
 Automation: {{ .AutomationObject }}
 
@@ -881,55 +887,88 @@ Images:
 {{ range .Updated.Images -}}
 - {{.}} ({{.Policy.Name}})
 {{ end -}}
-`
-
-	namespace, err := testEnv.CreateNamespace(ctx, "image-auto-test")
-	g.Expect(err).ToNot(HaveOccurred())
-	defer func() { g.Expect(testEnv.Delete(ctx, namespace)).To(Succeed()) }()
-
-	testWithRepoAndImagePolicy(
-		ctx, g, testEnv, namespace.Name, fixture, policySpec, latest,
-		func(g *WithT, s repoAndPolicyArgs, repoURL string, localRepo *extgogit.Repository) {
-			policyKey := types.NamespacedName{
-				Name:      s.imagePolicyName,
-				Namespace: s.namespace,
-			}
-			_ = testutil.CommitInRepo(ctx, g, repoURL, s.branch, originRemote, "Install setter marker", func(tmp string) {
-				g.Expect(testutil.ReplaceMarker(filepath.Join(tmp, "deploy.yaml"), policyKey)).To(Succeed())
-			})
-
-			preChangeCommitId := testutil.CommitIdFromBranch(localRepo, s.branch)
-			waitForNewHead(g, localRepo, s.branch, preChangeCommitId)
-			preChangeCommitId = testutil.CommitIdFromBranch(localRepo, s.branch)
-
-			updateStrategy := &imagev1.UpdateStrategy{
-				Strategy: imagev1.UpdateStrategySetters,
-			}
-			err := createImageUpdateAutomation(ctx, testEnv, "update-test", s.namespace, s.gitRepoName, s.gitRepoNamespace, s.branch, s.branch, "", removedTemplate, "", updateStrategy)
-			g.Expect(err).ToNot(HaveOccurred())
-			defer func() {
-				g.Expect(deleteImageUpdateAutomation(ctx, testEnv, "update-test", s.namespace)).To(Succeed())
-			}()
-
-			imageUpdateKey := types.NamespacedName{
-				Namespace: s.namespace,
-				Name:      "update-test",
-			}
-
-			g.Eventually(func() bool {
-				var imageUpdate imagev1.ImageUpdateAutomation
-				_ = testEnv.Get(context.TODO(), imageUpdateKey, &imageUpdate)
-				stalledCondition := apimeta.FindStatusCondition(imageUpdate.Status.Conditions, meta.StalledCondition)
-				return stalledCondition != nil &&
-					stalledCondition.Status == metav1.ConditionTrue &&
-					stalledCondition.Reason == imagev1.RemovedTemplateFieldReason &&
-					strings.Contains(stalledCondition.Message, "template uses removed '.Updated' field")
-			}, timeout).Should(BeTrue())
-
-			head, _ := localRepo.Head()
-			g.Expect(head.Hash().String()).To(Equal(preChangeCommitId))
+`,
+			expectedErrMsg: "template uses removed '.Updated' field",
 		},
-	)
+		{
+			name: ".Changed.ImageResult field",
+			template: `Commit summary
+
+Automation: {{ .AutomationObject }}
+
+Files:
+{{ range $filename, $_ := .Changed.ImageResult.Files -}}
+- {{ $filename }}
+{{ end -}}
+
+Objects:
+{{ range $resource, $_ := .Changed.ImageResult.Objects -}}
+- {{ $resource.Kind }} {{ $resource.Name }}
+{{ end -}}
+
+Images:
+{{ range .Changed.ImageResult.Images -}}
+- {{.}} ({{.Policy.Name}})
+{{ end -}}
+`,
+			expectedErrMsg: "template uses removed '.Changed.ImageResult' field",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			namespace, err := testEnv.CreateNamespace(ctx, "image-auto-test")
+			g.Expect(err).ToNot(HaveOccurred())
+			defer func() { g.Expect(testEnv.Delete(ctx, namespace)).To(Succeed()) }()
+
+			testWithRepoAndImagePolicy(
+				ctx, g, testEnv, namespace.Name, fixture, policySpec, latest,
+				func(g *WithT, s repoAndPolicyArgs, repoURL string, localRepo *extgogit.Repository) {
+					policyKey := types.NamespacedName{
+						Name:      s.imagePolicyName,
+						Namespace: s.namespace,
+					}
+					_ = testutil.CommitInRepo(ctx, g, repoURL, s.branch, originRemote, "Install setter marker", func(tmp string) {
+						g.Expect(testutil.ReplaceMarker(filepath.Join(tmp, "deploy.yaml"), policyKey)).To(Succeed())
+					})
+
+					preChangeCommitId := testutil.CommitIdFromBranch(localRepo, s.branch)
+					waitForNewHead(g, localRepo, s.branch, preChangeCommitId)
+					preChangeCommitId = testutil.CommitIdFromBranch(localRepo, s.branch)
+
+					updateStrategy := &imagev1.UpdateStrategy{
+						Strategy: imagev1.UpdateStrategySetters,
+					}
+					err := createImageUpdateAutomation(ctx, testEnv, "update-test", s.namespace, s.gitRepoName, s.gitRepoNamespace, s.branch, s.branch, "", tc.template, "", updateStrategy)
+					g.Expect(err).ToNot(HaveOccurred())
+					defer func() {
+						g.Expect(deleteImageUpdateAutomation(ctx, testEnv, "update-test", s.namespace)).To(Succeed())
+					}()
+
+					imageUpdateKey := types.NamespacedName{
+						Namespace: s.namespace,
+						Name:      "update-test",
+					}
+
+					g.Eventually(func() bool {
+						var imageUpdate imagev1.ImageUpdateAutomation
+						_ = testEnv.Get(context.TODO(), imageUpdateKey, &imageUpdate)
+						stalledCondition := apimeta.FindStatusCondition(imageUpdate.Status.Conditions, meta.StalledCondition)
+						return stalledCondition != nil &&
+							stalledCondition.Status == metav1.ConditionTrue &&
+							stalledCondition.Reason == imagev1.RemovedTemplateFieldReason &&
+							strings.Contains(stalledCondition.Message, tc.expectedErrMsg)
+					}, timeout).Should(BeTrue())
+
+					head, _ := localRepo.Head()
+					g.Expect(head.Hash().String()).To(Equal(preChangeCommitId))
+				},
+			)
+		})
+	}
 }
 
 func TestImageUpdateAutomationReconciler_crossNamespaceRef(t *testing.T) {
@@ -966,7 +1005,7 @@ func TestImageUpdateAutomationReconciler_crossNamespaceRef(t *testing.T) {
 	testWithCustomRepoAndImagePolicy(
 		ctx, g, testEnv, fixture, policySpec, latest, args,
 		func(g *WithT, s repoAndPolicyArgs, repoURL string, localRepo *extgogit.Repository) {
-			commitMessage := fmt.Sprintf(testCommitMessageFmt, s.namespace, s.imagePolicyName)
+			commitMessage := fmt.Sprintf(testCommitMessageFmt, s.namespace, s.namespace, s.imagePolicyName)
 
 			// Update the setter marker in the repo.
 			policyKey := types.NamespacedName{

--- a/internal/policy/applier.go
+++ b/internal/policy/applier.go
@@ -42,8 +42,8 @@ var (
 
 // ApplyPolicies applies the given set of policies on the source present in the
 // workDir based on the provided ImageUpdateAutomation configuration.
-func ApplyPolicies(ctx context.Context, workDir string, obj *imagev1.ImageUpdateAutomation, policies []imagev1_reflect.ImagePolicy) (update.ResultV2, error) {
-	var result update.ResultV2
+func ApplyPolicies(ctx context.Context, workDir string, obj *imagev1.ImageUpdateAutomation, policies []imagev1_reflect.ImagePolicy) (update.Result, error) {
+	var result update.Result
 	if obj.Spec.Update == nil {
 		return result, ErrNoUpdateStrategy
 	}
@@ -62,5 +62,5 @@ func ApplyPolicies(ctx context.Context, workDir string, obj *imagev1.ImageUpdate
 	}
 
 	tracelog := log.FromContext(ctx).V(logger.TraceLevel)
-	return update.UpdateV2WithSetters(tracelog, manifestPath, manifestPath, policies)
+	return update.UpdateWithSetters(tracelog, manifestPath, manifestPath, policies)
 }

--- a/internal/policy/applier_test.go
+++ b/internal/policy/applier_test.go
@@ -31,7 +31,6 @@ import (
 	imagev1 "github.com/fluxcd/image-automation-controller/api/v1beta2"
 	"github.com/fluxcd/image-automation-controller/internal/testutil"
 	"github.com/fluxcd/image-automation-controller/pkg/test"
-	"github.com/fluxcd/image-automation-controller/pkg/update"
 )
 
 func testdataPath(path string) string {
@@ -48,7 +47,6 @@ func Test_applyPolicies(t *testing.T) {
 		inputPath          string
 		expectedPath       string
 		wantErr            bool
-		wantResult         update.Result
 	}{
 		{
 			name: "valid update strategy and one policy",

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -55,8 +55,8 @@ import (
 )
 
 const (
-	originRemote       = "origin"
-	testCommitTemplate = `Commit summary
+	originRemote              = "origin"
+	testCommitTemplateRemoved = `Commit summary
 
 Automation: {{ .AutomationObject }}
 
@@ -469,31 +469,20 @@ func test_sourceManager_CommitAndPush(t *testing.T, proto string) {
 		checkRefSpecBranch string
 	}{
 		{
-			name: "push to cloned branch with custom template",
+			name: "push to cloned branch with removed template field",
 			gitSpec: &imagev1.GitSpec{
 				Push: &imagev1.PushSpec{
 					Branch: "main",
 				},
 				Commit: imagev1.CommitSpec{
-					MessageTemplate: testCommitTemplate,
+					MessageTemplate: testCommitTemplateRemoved,
 				},
 			},
 			gitRepoReference: &sourcev1.GitRepositoryRef{
 				Branch: "main",
 			},
 			latestImage: "helloworld:1.0.1",
-			wantErr:     false,
-			wantCommitMsg: `Commit summary
-
-Automation: test-ns/test-update
-
-Files:
-- deploy.yaml
-Objects:
-- deployment test
-Images:
-- helloworld:1.0.1 (policy1)
-`,
+			wantErr:     true,
 		},
 		{
 			name: "commit with update ResultV2 template",
@@ -771,6 +760,11 @@ Testing: value
 
 			pushResult, err := sm.CommitAndPush(ctx, updateAuto, result)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
+			if tt.wantErr {
+				g.Expect(pushResult).To(BeNil())
+				g.Expect(err).To(MatchError(ErrRemovedTemplateField))
+				return
+			}
 			if tt.noChange {
 				g.Expect(pushResult).To(BeNil())
 				return

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -102,6 +102,25 @@ Automation: {{ .AutomationObject }}
 Cluster: {{ index .Values "cluster" }}
 Testing: {{ .Values.testing }}
 `
+	testCommitTemplateImageResult = `Commit summary
+
+Automation: {{ .AutomationObject }}
+
+Files:
+{{ range $filename, $_ := .Changed.ImageResult.Files -}}
+- {{ $filename }}
+{{ end -}}
+
+Objects:
+{{ range $resource, $_ := .Changed.ImageResult.Objects -}}
+- {{ $resource.Kind }} {{ $resource.Name }}
+{{ end -}}
+
+Images:
+{{ range .Changed.ImageResult.Images -}}
+- {{.}} ({{.Policy.Name}})
+{{ end -}}
+`
 )
 
 func init() {
@@ -476,6 +495,22 @@ func test_sourceManager_CommitAndPush(t *testing.T, proto string) {
 				},
 				Commit: imagev1.CommitSpec{
 					MessageTemplate: testCommitTemplateRemoved,
+				},
+			},
+			gitRepoReference: &sourcev1.GitRepositoryRef{
+				Branch: "main",
+			},
+			latestImage: "helloworld:1.0.1",
+			wantErr:     true,
+		},
+		{
+			name: "push to cloned branch with removed ImageResult field",
+			gitSpec: &imagev1.GitSpec{
+				Push: &imagev1.PushSpec{
+					Branch: "main",
+				},
+				Commit: imagev1.CommitSpec{
+					MessageTemplate: testCommitTemplateImageResult,
 				},
 			},
 			gitRepoReference: &sourcev1.GitRepositoryRef{

--- a/pkg/update/result_test.go
+++ b/pkg/update/result_test.go
@@ -42,61 +42,10 @@ func TestMustRef(t *testing.T) {
 	})
 }
 
-func TestUpdateResults(t *testing.T) {
+func TestResult(t *testing.T) {
 	g := NewWithT(t)
 
 	var result Result
-	objectNames := []ObjectIdentifier{
-		{yaml.ResourceIdentifier{
-			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "foo"},
-		}},
-		{yaml.ResourceIdentifier{
-			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "bar"},
-		}},
-	}
-
-	result = Result{
-		Files: map[string]FileResult{
-			"foo.yaml": {
-				Objects: map[ObjectIdentifier][]ImageRef{
-					objectNames[0]: {
-						mustRef("image:v1.0"),
-						mustRef("other:v2.0"),
-					},
-				},
-			},
-			"bar.yaml": {
-				Objects: map[ObjectIdentifier][]ImageRef{
-					objectNames[1]: {
-						mustRef("image:v1.0"),
-						mustRef("other:v2.0"),
-					},
-				},
-			},
-		},
-	}
-
-	g.Expect(result.Images()).To(Equal([]ImageRef{
-		mustRef("image:v1.0"),
-		mustRef("other:v2.0"),
-	}))
-
-	g.Expect(result.Objects()).To(Equal(map[ObjectIdentifier][]ImageRef{
-		objectNames[0]: {
-			mustRef("image:v1.0"),
-			mustRef("other:v2.0"),
-		},
-		objectNames[1]: {
-			mustRef("image:v1.0"),
-			mustRef("other:v2.0"),
-		},
-	}))
-}
-
-func TestResultV2(t *testing.T) {
-	g := NewWithT(t)
-
-	var result ResultV2
 	objectNames := []ObjectIdentifier{
 		{yaml.ResourceIdentifier{
 			NameMeta: yaml.NameMeta{Namespace: "ns", Name: "foo"},
@@ -117,7 +66,7 @@ func TestResultV2(t *testing.T) {
 		Setter:   "foo-ns:policy",
 	})
 
-	result = ResultV2{
+	result = Result{
 		FileChanges: map[string]ObjectChanges{
 			"foo.yaml": {
 				objectNames[0]: []Change{

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -20,10 +20,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/fluxcd/image-automation-controller/internal/testutil"
@@ -64,6 +62,7 @@ func TestUpdateWithSetters(t *testing.T) {
 		},
 	}
 
+	// Test Result.
 	tmp := t.TempDir()
 	result, err := UpdateWithSetters(logr.Discard(), "testdata/setters/original", tmp, policies)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -86,55 +85,7 @@ func TestUpdateWithSetters(t *testing.T) {
 		},
 	}}
 
-	r, _ := name.ParseReference("index.repo.fake/updated:v1.0.1")
-	expectedImageRef := imageRef{r, types.NamespacedName{
-		Name:      "policy",
-		Namespace: "automation-ns",
-	}}
-
-	r, _ = name.ParseReference("image:v1.0.0@sha256:6745aaad46d795c9836632e1fb62f24b7e7f4c843144da8e47a5465c411a14be")
-	expectedImageRefDigest := imageRef{r, types.NamespacedName{
-		Name:      "policy-with-digest",
-		Namespace: "automation-ns",
-	}}
-
 	expectedResult := Result{
-		Files: map[string]FileResult{
-			"kustomization.yml": {
-				Objects: map[ObjectIdentifier][]ImageRef{
-					kustomizeResourceID: {
-						expectedImageRef,
-						expectedImageRefDigest,
-					},
-				},
-			},
-			"Kustomization": {
-				Objects: map[ObjectIdentifier][]ImageRef{
-					kustomizeResourceID: {
-						expectedImageRef,
-					},
-				},
-			},
-			"marked.yaml": {
-				Objects: map[ObjectIdentifier][]ImageRef{
-					markedResourceID: {
-						expectedImageRef,
-					},
-				},
-			},
-		},
-	}
-
-	g.Expect(result).To(Equal(expectedResult))
-
-	// Test ResultV2.
-	tmp2 := t.TempDir()
-	resultV2, err := UpdateV2WithSetters(logr.Discard(), "testdata/setters/original", tmp2, policies)
-	g.Expect(err).ToNot(HaveOccurred())
-	test.ExpectMatchingDirectories(g, tmp2, "testdata/setters/expected")
-
-	expectedResultV2 := ResultV2{
-		ImageResult: expectedResult,
 		FileChanges: map[string]ObjectChanges{
 			"kustomization.yml": {
 				kustomizeResourceID: []Change{
@@ -186,5 +137,5 @@ func TestUpdateWithSetters(t *testing.T) {
 		},
 	}
 
-	g.Expect(resultV2).To(Equal(expectedResultV2))
+	g.Expect(result).To(Equal(expectedResult))
 }


### PR DESCRIPTION
Implement https://github.com/fluxcd/flux2/issues/5411#issuecomment-2994361145 as part of GA preparation work.

This PR addresses two breaking changes for ImageUpdateAutomation API GA preparation:

1. **Template field `.Updated` removal** (commit d35a65c): The `.Updated` template field has been deprecated and removed. Users should migrate to `.Changed` instead.

2. **Template field `.Changed.ImageResult` removal** (commit 9176026): As part of Result/ResultV2 type consolidation, the `.Changed.ImageResult` template field has been removed. Users should migrate to:
   - `.Changed.FileChanges` for detailed change tracking
   - `.Changed.Objects` for object-level changes
   - `.Changed.Changes` for a flat list of changes

Both changes include appropriate error handling with migration guidance when deprecated fields are used in templates.