### PR TITLE
Fix: Prioritize sha2-512 and sha2-256 for ssh-rsa host keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/fluxcd/pkg/auth v0.17.0
 	github.com/fluxcd/pkg/cache v0.9.0
 	github.com/fluxcd/pkg/git v0.32.0
-	github.com/fluxcd/pkg/git/gogit v0.35.0
+	github.com/fluxcd/pkg/git/gogit v0.35.1
 	github.com/fluxcd/pkg/gittestserver v0.17.0
 	github.com/fluxcd/pkg/runtime v0.60.0
 	github.com/fluxcd/pkg/ssh v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/fluxcd/pkg/cache v0.9.0 h1:EGKfOLMG3fOwWnH/4Axl5xd425mxoQbZzlZoLfd8PD
 github.com/fluxcd/pkg/cache v0.9.0/go.mod h1:jMwabjWfsC5lW8hE7NM3wtGNwSJ38Javx6EKbEi7INU=
 github.com/fluxcd/pkg/git v0.32.0 h1:agSE4Ia8saj5eg075qhLhZvjuTg/Hnj8mZU0meGKOyc=
 github.com/fluxcd/pkg/git v0.32.0/go.mod h1:rUgLXVQGBkBggHOLVMhHMHaweQ8Oc6HwZiN2Zm08Zxs=
-github.com/fluxcd/pkg/git/gogit v0.35.0 h1:uMFFwhg3X4H2GaJtXBG/sEv5yrIUk7gIdIpayTLXdC0=
-github.com/fluxcd/pkg/git/gogit v0.35.0/go.mod h1:/WcAqTDBrjF+6cwFTaK7kNM791j/pXmw0fy8xbd1YWo=
+github.com/fluxcd/pkg/git/gogit v0.35.1 h1:NZI7rWDUUaGhEqgbvlh2CK9UZU/eteQ3eDTEMvdHmBo=
+github.com/fluxcd/pkg/git/gogit v0.35.1/go.mod h1:/WcAqTDBrjF+6cwFTaK7kNM791j/pXmw0fy8xbd1YWo=
 github.com/fluxcd/pkg/gittestserver v0.17.0 h1:JlBvWZQTDOI+np5Z+084m3DkeAH1hMusEybyRUDF63k=
 github.com/fluxcd/pkg/gittestserver v0.17.0/go.mod h1:E/40EmLoXcMqd6gLuLDC9F6KJxqHVGbBBeMNKk5XdxU=
 github.com/fluxcd/pkg/runtime v0.60.0 h1:d++EkV3FlycB+bzakB5NumwY4J8xts8i7lbvD6jBLeU=


### PR DESCRIPTION
Update `github.com/fluxcd/pkg/git/gogit` to v0.35.1 which includes: https://github.com/fluxcd/pkg/pull/954

This PR fixes a regression bug introduce in https://github.com/fluxcd/pkg/pull/943:

```
ssh: handshake failed: ssh: no common algorithm for host key;
client offered: [ssh-rsa], server offered: [rsa-sha2-512 rsa-sha2-256]
```

xref: https://github.com/fluxcd/source-controller/pull/1839