### PR TITLE
Release v0.41.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.41.2
+
+**Release date:** 2025-06-27
+
+This patch release comes with a fix for `rsa-sha2-512` and `rsa-sha2-256` algorithms
+not being prioritized for `ssh-rsa` host keys.
+
+Fixes:
+- Fix: Prioritize sha2-512 and sha2-256 for ssh-rsa host keys
+  [#932](https://github.com/fluxcd/image-automation-controller/pull/932)
+
 ## 0.41.1
 
 **Release date:** 2025-06-13

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: fluxcd/image-automation-controller
   newName: fluxcd/image-automation-controller
-  newTag: v0.41.1
+  newTag: v0.41.2

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ProtonMail/go-crypto v1.2.0
 	github.com/cyphar/filepath-securejoin v0.4.1
-	github.com/fluxcd/image-automation-controller/api v0.41.1
+	github.com/fluxcd/image-automation-controller/api v0.41.2
 	github.com/fluxcd/image-reflector-controller/api v0.35.2
 	github.com/fluxcd/pkg/apis/acl v0.7.0
 	github.com/fluxcd/pkg/apis/event v0.17.0


### PR DESCRIPTION
This patch release comes with a fix for `rsa-sha2-512` and `rsa-sha2-256` algorithms not being prioritized for `ssh-rsa` host keys.