### PR TITLE
fix: propagate non-not-found errors when fetching GitRepository

### DIFF
--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -76,6 +76,7 @@ func buildGitConfig(ctx context.Context, c client.Client, originKey, srcKey type
 		if client.IgnoreNotFound(err) == nil {
 			return nil, fmt.Errorf("referenced git repository does not exist: %w", err)
 		}
+		return nil, fmt.Errorf("failed to get referenced git repository: %w", err)
 	}
 	cfg.url = repo.Spec.URL
 
@@ -89,7 +90,6 @@ func buildGitConfig(ctx context.Context, c client.Client, originKey, srcKey type
 	// Get the checkout ref for the source, prioritizing the image automation
 	// object gitSpec checkout reference and falling back to the GitRepository
 	// reference if not provided.
-	// var checkoutRef *sourcev1.GitRepositoryRef
 	if gitSpec.Checkout != nil {
 		cfg.checkoutRef = &gitSpec.Checkout.Reference
 	} else if repo.Spec.Reference != nil {

--- a/internal/source/git_test.go
+++ b/internal/source/git_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/auth/aws"
@@ -405,7 +406,9 @@ func Test_buildGitConfig(t *testing.T) {
 		gitRepoURL       string
 		gitRepoProxyData map[string][]byte
 		srcOpts          SourceOptions
+		injectGetError   error
 		wantErr          bool
+		wantErrContains  string
 		wantCheckoutRef  *sourcev1.GitRepositoryRef
 		wantPushBranch   string
 		wantSwitchBranch bool
@@ -528,6 +531,20 @@ func Test_buildGitConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "transient error fetching gitRepo",
+			gitSpec: &imagev1.GitSpec{
+				Checkout: &imagev1.GitCheckoutSpec{
+					Reference: sourcev1.GitRepositoryRef{Branch: "main"},
+				},
+				Push: &imagev1.PushSpec{Branch: "main"},
+			},
+			gitRepoName:     testGitRepoName,
+			gitRepoURL:      testGitURL,
+			injectGetError:  fmt.Errorf("transient-test-error"),
+			wantErr:         true,
+			wantErrContains: "transient-test-error",
+		},
+		{
 			name:        "use gitrepo timeout",
 			gitSpec:     &imagev1.GitSpec{},
 			gitRepoName: testGitRepoName,
@@ -616,6 +633,17 @@ func Test_buildGitConfig(t *testing.T) {
 			clientBuilder := fakeclient.NewClientBuilder().
 				WithScheme(scheme.Scheme).
 				WithObjects(testObjects...)
+			if tt.injectGetError != nil {
+				injectErr := tt.injectGetError
+				clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*sourcev1.GitRepository); ok {
+							return injectErr
+						}
+						return cl.Get(ctx, key, obj, opts...)
+					},
+				})
+			}
 			c := clientBuilder.Build()
 
 			gitRepoKey := types.NamespacedName{
@@ -632,6 +660,9 @@ func Test_buildGitConfig(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				g.Fail(fmt.Sprintf("unexpected error: %v", err))
 				return
+			}
+			if tt.wantErrContains != "" {
+				g.Expect(err.Error()).To(ContainSubstring(tt.wantErrContains))
 			}
 			if err == nil {
 				g.Expect(gitSrcCfg.checkoutRef).To(Equal(tt.wantCheckoutRef), "unexpected checkoutRef")


### PR DESCRIPTION
In `buildGitConfig`, non-not-found errors from `c.Get` (RBAC issue, transient API hiccup, etc.) are silently swallowed. The function then continues with an empty `GitRepository{}` and fails later with `failed to configure authentication options: no transport type set` instead of the real cause.

Root cause: `client.IgnoreNotFound(err) == nil` is true when the error *is* not-found, so the inner `return` only fires for that case. Non-not-found errors fall through with no return.

Fix adds the missing `return` for all other errors.

To reproduce: use `WithInterceptorFuncs` to inject a non-not-found error on `c.Get` for a `GitRepository`. The new test case `transient error fetching gitRepo` does exactly that and fails on unpatched code.

Also removes a stale `// var checkoutRef` comment.

## Test plan

- [x] `go test ./internal/source/... -run Test_buildGitConfig` passes
- [x] New test fails on unpatched code, passes with fix