### PR TITLE
Migrate event recorder to fluxcd/pkg/runtime/events.Recorder

### DIFF
--- a/internal/controller/imageupdateautomation_controller.go
+++ b/internal/controller/imageupdateautomation_controller.go
@@ -26,9 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	kuberecorder "k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -41,7 +39,7 @@ import (
 
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1"
 	aclapi "github.com/fluxcd/pkg/apis/acl"
-	eventv1 "github.com/fluxcd/pkg/apis/event/v1beta1"
+	eventv1 "github.com/fluxcd/pkg/apis/event/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/auth"
 	"github.com/fluxcd/pkg/cache"
@@ -49,6 +47,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	helper "github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/runtime/predicates"
 	runtimereconcile "github.com/fluxcd/pkg/runtime/reconcile"
@@ -102,7 +101,7 @@ func getPatchOptions(ownedConditions []string, controllerName string) []patch.Op
 // ImageUpdateAutomationReconciler reconciles a ImageUpdateAutomation object
 type ImageUpdateAutomationReconciler struct {
 	client.Client
-	kuberecorder.EventRecorder
+	events.EventRecorder
 	helper.Metrics
 
 	ControllerName      string
@@ -608,6 +607,7 @@ func observedPoliciesChanged(previous, current imagev1.ObservedPolicies) bool {
 // case of any failure, the failure message is read from the Ready condition and
 // included in the event.
 func (r *ImageUpdateAutomationReconciler) notify(ctx context.Context, oldObj, newObj conditions.Setter, result *source.PushResult, syncNeeded bool) {
+	related := sourceRefObject(newObj)
 	// Use the Ready message as the notification message by default.
 	ready := conditions.Get(newObj, meta.ReadyCondition)
 	msg := ready.Message
@@ -619,7 +619,7 @@ func (r *ImageUpdateAutomationReconciler) notify(ctx context.Context, oldObj, ne
 
 	// Was ready before and is ready now, with new push result,
 	if conditions.IsReady(oldObj) && conditions.IsReady(newObj) && result != nil {
-		eventLogf(ctx, r.EventRecorder, newObj, corev1.EventTypeNormal, ready.Reason, "%s", msg)
+		r.Eventf(newObj, related, corev1.EventTypeNormal, ready.Reason, "", "%s", msg)
 		return
 	}
 
@@ -627,12 +627,12 @@ func (r *ImageUpdateAutomationReconciler) notify(ctx context.Context, oldObj, ne
 
 	// Became ready from not ready.
 	if !conditions.IsReady(oldObj) && conditions.IsReady(newObj) {
-		eventLogf(ctx, r.EventRecorder, newObj, corev1.EventTypeNormal, ready.Reason, "%s", msg)
+		r.Eventf(newObj, related, corev1.EventTypeNormal, ready.Reason, "", "%s", msg)
 		return
 	}
 	// Not ready, failed. Use the failure message from ready condition.
 	if !conditions.IsReady(newObj) {
-		eventLogf(ctx, r.EventRecorder, newObj, corev1.EventTypeWarning, ready.Reason, "%s", ready.Message)
+		r.Eventf(newObj, related, corev1.EventTypeWarning, ready.Reason, "", "%s", ready.Message)
 		return
 	}
 
@@ -642,21 +642,30 @@ func (r *ImageUpdateAutomationReconciler) notify(ctx context.Context, oldObj, ne
 		// Full reconciliation skipped.
 		msg = "no change since last reconciliation"
 	}
-	eventLogf(ctx, r.EventRecorder, newObj, eventv1.EventTypeTrace, meta.SucceededReason, "%s", msg)
+	r.Eventf(newObj, related, eventv1.EventTypeTrace, meta.SucceededReason, "", "%s", msg)
 }
 
-// eventLogf records events, and logs at the same time.
-//
-// This log is different from the debug log in the EventRecorder, in the sense
-// that this is a simple log. While the debug log contains complete details
-// about the event.
-func eventLogf(ctx context.Context, r kuberecorder.EventRecorder, obj runtime.Object, eventType string, reason string, messageFmt string, args ...interface{}) {
-	msg := fmt.Sprintf(messageFmt, args...)
-	// Log and emit event.
-	if eventType == corev1.EventTypeWarning {
-		ctrl.LoggerFrom(ctx).Error(errors.New(reason), msg)
-	} else {
-		ctrl.LoggerFrom(ctx).Info(msg)
+// sourceRefObject returns a minimal GitRepository object for use as the
+// related object in events. It extracts the source reference from the
+// ImageUpdateAutomation spec.
+func sourceRefObject(obj conditions.Setter) *sourcev1.GitRepository {
+	auto, ok := obj.(*imagev1.ImageUpdateAutomation)
+	if !ok {
+		return nil
 	}
-	r.Eventf(obj, eventType, reason, "%s", msg)
+	ref := auto.Spec.SourceRef
+	ns := ref.Namespace
+	if ns == "" {
+		ns = auto.Namespace
+	}
+	return &sourcev1.GitRepository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       sourcev1.GitRepositoryKind,
+			APIVersion: sourcev1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ref.Name,
+			Namespace: ns,
+		},
+	}
 }

--- a/internal/controller/imageupdateautomation_controller_test.go
+++ b/internal/controller/imageupdateautomation_controller_test.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -55,6 +54,7 @@ import (
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	conditionscheck "github.com/fluxcd/pkg/runtime/conditions/check"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/patch"
 	"github.com/fluxcd/pkg/ssh"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -132,7 +132,7 @@ func TestImageUpdateAutomationReconciler_deleteBeforeFinalizer(t *testing.T) {
 
 	r := &ImageUpdateAutomationReconciler{
 		Client:        k8sClient,
-		EventRecorder: record.NewFakeRecorder(32),
+		EventRecorder: events.NewFakeRecorder(32, false),
 	}
 	// NOTE: Only a real API server responds with an error in this scenario.
 	g.Eventually(func() error {
@@ -1061,7 +1061,7 @@ func TestImageUpdateAutomationReconciler_crossNamespaceRef(t *testing.T) {
 			WithScheme(testEnv.Scheme()).
 			WithStatusSubresource(&imagev1.ImageUpdateAutomation{}, &reflectorv1.ImagePolicy{}).
 			Build(),
-		EventRecorder:       testEnv.GetEventRecorderFor("image-automation-controller"),
+		EventRecorder:       testEnv.GetEventRecorder("image-automation-controller"),
 		NoCrossNamespaceRef: true,
 	}
 
@@ -1993,7 +1993,7 @@ func TestImageUpdateAutomationReconciler_notify(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			recorder := record.NewFakeRecorder(32)
+			recorder := events.NewFakeRecorder(32, false)
 
 			oldObj := &imagev1.ImageUpdateAutomation{}
 			newObj := oldObj.DeepCopy()
@@ -2011,10 +2011,11 @@ func TestImageUpdateAutomationReconciler_notify(t *testing.T) {
 			reconciler.notify(ctx, oldObj, newObj, tt.pushResult, tt.syncNeeded)
 
 			select {
-			case x, ok := <-recorder.Events:
+			case ev, ok := <-recorder.Events:
 				g.Expect(ok).To(Equal(tt.wantEvent != ""), "unexpected event received")
 				if tt.wantEvent != "" {
-					g.Expect(x).To(ContainSubstring(tt.wantEvent))
+					got := fmt.Sprintf("%s %s %s", ev.Type, ev.Reason, ev.Note)
+					g.Expect(got).To(ContainSubstring(tt.wantEvent))
 				}
 			default:
 				if tt.wantEvent != "" {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -26,12 +26,12 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1"
 	"github.com/fluxcd/pkg/runtime/controller"
+	"github.com/fluxcd/pkg/runtime/events"
 	"github.com/fluxcd/pkg/runtime/testenv"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
@@ -87,7 +87,7 @@ func runTestsWithFeatures(m *testing.M, feats map[string]bool) int {
 	controllerName := "image-automation-controller"
 	if err := (&ImageUpdateAutomationReconciler{
 		Client:         testEnv,
-		EventRecorder:  record.NewFakeRecorder(32),
+		EventRecorder:  events.NewFakeRecorder(32, false),
 		features:       feats,
 		ControllerName: controllerName,
 	}).SetupWithManager(ctx, testEnv, ImageUpdateAutomationReconcilerOptions{

--- a/main.go
+++ b/main.go
@@ -26,7 +26,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +36,7 @@ import (
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1"
 	"github.com/fluxcd/pkg/auth"
 	cache "github.com/fluxcd/pkg/cache"
+	"github.com/fluxcd/pkg/git"
 	"github.com/fluxcd/pkg/runtime/acl"
 	"github.com/fluxcd/pkg/runtime/client"
 	helper "github.com/fluxcd/pkg/runtime/controller"
@@ -48,8 +48,6 @@ import (
 	"github.com/fluxcd/pkg/runtime/pprof"
 	"github.com/fluxcd/pkg/runtime/probes"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
-	"github.com/fluxcd/pkg/git"
 
 	imagev1 "github.com/fluxcd/image-automation-controller/api/v1"
 	"github.com/fluxcd/image-automation-controller/internal/features"
@@ -196,7 +194,7 @@ func main() {
 			ExtraHandlers: pprof.GetHandlers(),
 		},
 		Controller: ctrlcfg.Controller{
-			RecoverPanic:            pointer.Bool(true),
+			RecoverPanic:            new(true),
 			MaxConcurrentReconciles: concurrent,
 		},
 	}
@@ -215,8 +213,8 @@ func main() {
 
 	probes.SetupChecks(mgr, setupLog)
 
-	var eventRecorder *events.Recorder
-	if eventRecorder, err = events.NewRecorder(mgr, ctrl.Log, eventsAddr, controllerName); err != nil {
+	eventRecorder, err := events.NewRecorder(mgr, ctrl.Log, eventsAddr, controllerName)
+	if err != nil {
 		setupLog.Error(err, "unable to create event recorder")
 		os.Exit(1)
 	}


### PR DESCRIPTION
- Replace kuberecorder.EventRecorder with fluxcd/events.Recorder to support structured event metadata including source object and action type.
- Upgrade event API from event/v1beta1 to event/v1
- Add action parameter (Reconciled, Failed, Waiting, Applied, Deleted, Progressing) to all event calls for richer event semantics.
- Pass source reference through reconcile, apply, prune, checkHealth, and finalize methods.
- Update tests to use events.Recorder.

Closes https://github.com/fluxcd/flux2/issues/5761