### PR TITLE
fix: Preserve all object changes

### DIFF
--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -35,12 +35,14 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1"
 	"github.com/fluxcd/pkg/apis/meta"
@@ -52,6 +54,7 @@ import (
 	imagev1 "github.com/fluxcd/image-automation-controller/api/v1"
 	"github.com/fluxcd/image-automation-controller/internal/policy"
 	"github.com/fluxcd/image-automation-controller/internal/testutil"
+	"github.com/fluxcd/image-automation-controller/internal/update"
 )
 
 const (
@@ -141,6 +144,55 @@ func Fuzz_templateMsg(f *testing.F) {
 
 		_, _ = templateMsg(template, &values)
 	})
+}
+
+func TestTemplateMsgAggregatesObjectChangesAcrossFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	objectID := update.ObjectIdentifier{ResourceIdentifier: yaml.ResourceIdentifier{
+		TypeMeta: yaml.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		NameMeta: yaml.NameMeta{
+			Namespace: "default",
+			Name:      "podinfo",
+		},
+	}}
+
+	templateValues := &TemplateData{
+		AutomationObject: types.NamespacedName{
+			Namespace: "flux-system",
+			Name:      "podinfo",
+		},
+		Changed: update.Result{
+			FileChanges: map[string]update.ObjectChanges{
+				"base/deployment.yaml": {
+					objectID: []update.Change{
+						{
+							OldValue: "podinfo:v1.0.0",
+							NewValue: "podinfo:v1.0.1",
+							Setter:   "flux-system:podinfo",
+						},
+					},
+				},
+				"overlays/prod/deployment.yaml": {
+					objectID: []update.Change{
+						{
+							OldValue: "1",
+							NewValue: "2",
+							Setter:   "flux-system:replicas",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	msg, err := templateMsg(testCommitTemplateResultV2, templateValues)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(msg).To(ContainSubstring("- podinfo:v1.0.0 -> podinfo:v1.0.1"))
+	g.Expect(msg).To(ContainSubstring("- 1 -> 2"))
 }
 
 func TestNewSourceManager(t *testing.T) {

--- a/internal/update/result.go
+++ b/internal/update/result.go
@@ -126,7 +126,7 @@ func (r Result) Objects() ObjectChanges {
 	result := make(ObjectChanges)
 	for _, objChanges := range r.FileChanges {
 		for obj, change := range objChanges {
-			result[obj] = change
+			result[obj] = append(result[obj], change...)
 		}
 	}
 	return result

--- a/internal/update/result_test.go
+++ b/internal/update/result_test.go
@@ -134,3 +134,56 @@ func TestResult(t *testing.T) {
 		},
 	}))
 }
+
+func TestResultObjectsAggregatesSameObjectAcrossFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	objectID := ObjectIdentifier{yaml.ResourceIdentifier{
+		TypeMeta: yaml.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		NameMeta: yaml.NameMeta{
+			Namespace: "default",
+			Name:      "podinfo",
+		},
+	}}
+
+	result := Result{
+		FileChanges: map[string]ObjectChanges{
+			"base/deployment.yaml": {
+				objectID: []Change{
+					{
+						OldValue: "podinfo:v1.0.0",
+						NewValue: "podinfo:v1.0.1",
+						Setter:   "flux-system:podinfo",
+					},
+				},
+			},
+			"overlays/prod/deployment.yaml": {
+				objectID: []Change{
+					{
+						OldValue: "1",
+						NewValue: "2",
+						Setter:   "flux-system:replicas",
+					},
+				},
+			},
+		},
+	}
+
+	objects := result.Objects()
+	g.Expect(objects).To(HaveKey(objectID))
+	g.Expect(objects[objectID]).To(ContainElements(
+		Change{
+			OldValue: "podinfo:v1.0.0",
+			NewValue: "podinfo:v1.0.1",
+			Setter:   "flux-system:podinfo",
+		},
+		Change{
+			OldValue: "1",
+			NewValue: "2",
+			Setter:   "flux-system:replicas",
+		},
+	))
+}


### PR DESCRIPTION
`.Changed.Objects` was overwriting earlier entries when the same object id showed up under more than one file.

This is triggerable in real repos, especially Kustomize style layouts where a base and an overlay both carry the same object. In that case commit templates only show part of the diff, which is pretty sneaky.

Repro:
1. Build an `update.Result` with the same `ObjectIdentifier` in two files.
2. Render a template that ranges over `.Changed.Objects`.
3. Before this patch, only the last file changes show up.
4. After this patch, both changes show up.

Tests:
- add a regression test for `Result.Objects()`
- add a template level regression test for `.Changed.Objects`
