### PR TITLE
build: target host arch for local builds/envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ CRD_OPTIONS ?= crd:crdVersions=v1
 # Allows for defining additional Docker buildx arguments,
 # e.g. '--push'.
 BUILD_ARGS ?=
-# Architectures to build images for
-BUILD_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7
+# Host architecture, used so local builds and envtest target the host.
+LOCALARCH ?= $(shell go env GOARCH)
+# Architectures to build images for; defaults to the host architecture.
+BUILD_PLATFORMS ?= linux/$(LOCALARCH)
 
 # Allows for defining additional Go test args, e.g. '-tags integration'.
 GO_TEST_ARGS ?= -race
@@ -46,25 +48,13 @@ export GOBIN=$(shell go env GOBIN)
 endif
 export PATH:=${GOBIN}:${PATH}
 
-# Architecture to use envtest with
-ifeq ($(shell uname -m),x86_64)
-ENVTEST_ARCH ?= amd64
-else
-ENVTEST_ARCH ?= arm64
-endif
-
-ifeq ($(shell uname -s),Darwin)
-# Envtest only supports darwin-amd64
-ENVTEST_ARCH=amd64
-endif
+# Architecture to use envtest with; defaults to the host architecture.
+ENVTEST_ARCH ?= $(LOCALARCH)
 
 TEST_CRDS := internal/controller/testdata/crds
 
 # Log level for `make run`
 LOG_LEVEL ?= info
-
-# Architecture to use envtest with
-ENVTEST_ARCH ?= amd64
 
 all: manager
 


### PR DESCRIPTION
On arm64 hosts, builds would use amd64 for both:
- `ENVTEST_ARCH` test binaries
- `BUILD_PLATFORMS` for `make docker-build`

So local builds and tests run under emulation (Rosetta) on arm64 hosts, which is slow and occasionally hides subtle runtime bugs like the ones i ran into testing helm-controller. envtest publishes native arm64 binaries now (including darwin/arm64), so the pin and Darwin override is no longer needed.

now:
- `ENVTEST_ARCH` follows the host arch
- `BUILD_PLATFORMS` defaults to `linux/<host arch>` so `make docker-build` makes a native image

overrides still work:
`make docker-build BUILD_PLATFORMS=linux/amd64,linux/arm64,linux/arm/v7`

Multi-arch release images come from the fluxcd/gha-workflows release flow, not `make docker-build`, so release artifacts are untouched.
I ran all tests and docker-builds across the 9 repos via apple silicon

tracking: https://github.com/fluxcd/flux2/issues/5931