### PR TITLE
Add categories to ImageUpdateAutomation CRD

### DIFF
--- a/api/v1/imageupdateautomation_types.go
+++ b/api/v1/imageupdateautomation_types.go
@@ -132,7 +132,7 @@ type ObservedPolicies map[string]ImageRef
 //+kubebuilder:storageversion
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=iua;imgupd;imgauto
+//+kubebuilder:resource:shortName=iua;imgupd;imgauto,categories=all;fluxcd;fluxcd-images
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",description=""
 //+kubebuilder:printcolumn:name="Last run",type="string",JSONPath=".status.lastAutomationRunTime",priority=1

--- a/api/v1beta2/imageupdateautomation_types.go
+++ b/api/v1beta2/imageupdateautomation_types.go
@@ -130,7 +130,6 @@ type ImageUpdateAutomationStatus struct {
 type ObservedPolicies map[string]ImageRef
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName=iua;imgupd;imgauto
 // +kubebuilder:skipversion
 
 // ImageUpdateAutomation is the Schema for the imageupdateautomations API

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -8,6 +8,10 @@ metadata:
 spec:
   group: image.toolkit.fluxcd.io
   names:
+    categories:
+    - all
+    - fluxcd
+    - fluxcd-images
     kind: ImageUpdateAutomation
     listKind: ImageUpdateAutomationList
     plural: imageupdateautomations


### PR DESCRIPTION
This adds the standard Flux resource categories to the ImageUpdateAutomation CRD in this
repository so users can list Flux resources with kubectl, for example:

```
kubectl get fluxcd          # all Flux resources
kubectl get fluxcd-images   # all resources in this category
kubectl get all             # now includes Flux resources
```

Each CRD gets exactly three categories:

```
all
fluxcd
fluxcd-images
```

The `+kubebuilder:resource` markers were removed from the skipped older
API versions, since they interfere with CRD generation, and the CRDs
were regenerated with `make manifests`.

Part of fluxcd/flux2#5947
