### PR TITLE
Remove stray Go declaration from doc-comment

### DIFF
--- a/api/v1/imageupdateautomation_types.go
+++ b/api/v1/imageupdateautomation_types.go
@@ -116,7 +116,6 @@ type ImageUpdateAutomationStatus struct {
 	// considered by the ImageUpdateAutomation update process.
 	// +optional
 	ObservedPolicies ObservedPolicies `json:"observedPolicies,omitempty"`
-	// ObservedPolicies []ObservedPolicy `json:"observedPolicies,omitempty"`
 	// ObservedSourceRevision is the last observed source revision. This can be
 	// used to determine if the source has been updated since last observation.
 	// +optional

--- a/api/v1beta2/imageupdateautomation_types.go
+++ b/api/v1beta2/imageupdateautomation_types.go
@@ -116,7 +116,6 @@ type ImageUpdateAutomationStatus struct {
 	// considered by the ImageUpdateAutomation update process.
 	// +optional
 	ObservedPolicies ObservedPolicies `json:"observedPolicies,omitempty"`
-	// ObservedPolicies []ObservedPolicy `json:"observedPolicies,omitempty"`
 	// ObservedSourceRevision is the last observed source revision. This can be
 	// used to determine if the source has been updated since last observation.
 	// +optional

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -436,7 +436,6 @@ spec:
                 type: object
               observedSourceRevision:
                 description: |-
-                  ObservedPolicies []ObservedPolicy `json:"observedPolicies,omitempty"`
                   ObservedSourceRevision is the last observed source revision. This can be
                   used to determine if the source has been updated since last observation.
                 type: string

--- a/docs/api/v1/image-automation.md
+++ b/docs/api/v1/image-automation.md
@@ -712,8 +712,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ObservedPolicies []ObservedPolicy <code>json:&quot;observedPolicies,omitempty&quot;</code>
-ObservedSourceRevision is the last observed source revision. This can be
+<p>ObservedSourceRevision is the last observed source revision. This can be
 used to determine if the source has been updated since last observation.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Summary

Part of fluxcd/flux2#5941 (item 3) — a leftover line from the `ObservedPolicies` field's previous Go struct declaration (`ObservedPolicies []ObservedPolicy \`json:"observedPolicies,omitempty"\``) had ended up inside the *next* field's (`ObservedSourceRevision`) doc-comment, leaking verbatim into the generated CRD description text. Removed in both `api/v1` and `api/v1beta2`, and regenerated the CRD.

Cosmetic/documentation only — no functional or behavioral change.

## Test plan

- `go build ./...` and `cd api && go build ./...` — clean.
- `gofmt -l` on changed files — no output (already formatted).
- `go vet` in the `api` submodule — clean.
- Regenerated `config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml` via `controller-gen crd:crdVersions=v1 rbac:roleName=manager-role paths="./..." output:crd:artifacts:config="config/crd/bases"` (same invocation as `make manifests`); diff confirmed to be exactly the one stray line removed, nothing else changed.