### PR TITLE
Fix branch switch failure with symlink changes

### DIFF
--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -116,7 +116,8 @@ func buildGitConfig(ctx context.Context, c client.Client, originKey, srcKey type
 	if err != nil {
 		return nil, err
 	}
-	cfg.clientOpts = []gogit.ClientOption{gogit.WithDiskStorage()}
+	// The storage options are configured at checkout time, once the
+	// working directory is known. See SourceManager.CheckoutSource.
 	if cfg.authOpts.Transport == git.HTTP {
 		cfg.clientOpts = append(cfg.clientOpts, gogit.WithInsecureCredentialsOverHTTP())
 	}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -254,8 +254,16 @@ func (sm *SourceManager) CheckoutSource(ctx context.Context, options ...Checkout
 		o(&cloneCfg)
 	}
 
-	var err error
-	sm.gitClient, err = gogit.NewClient(sm.workingDir, sm.srcCfg.authOpts, sm.srcCfg.clientOpts...)
+	// Configure the client to store the repository on disk, using a
+	// worktree filesystem that keeps branch switching involving symlinks
+	// safe. See the documentation of worktreeFS.
+	clientOpts, err := diskStorageClientOptions(sm.workingDir)
+	if err != nil {
+		return nil, err
+	}
+	clientOpts = append(clientOpts, sm.srcCfg.clientOpts...)
+
+	sm.gitClient, err = gogit.NewClient(sm.workingDir, sm.srcCfg.authOpts, clientOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -534,6 +534,128 @@ func test_sourceManager_CheckoutSource(t *testing.T, proto string) {
 	}
 }
 
+// TestSourceManager_CheckoutSource_symlinkSwitchBranch tests that
+// switching to a push branch that has fallen behind the checkout ref
+// succeeds when the changes between both branches involve symlinks, and
+// that the switch operates on the symlinks themselves, never on their
+// targets. Regression test for
+// https://github.com/fluxcd/image-automation-controller/issues/1037.
+func TestSourceManager_CheckoutSource_symlinkSwitchBranch(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+	testNS := "test-ns"
+
+	// Run git server.
+	gitServer := testutil.SetUpGitTestServer(g)
+	t.Cleanup(func() {
+		g.Expect(os.RemoveAll(gitServer.Root())).ToNot(HaveOccurred())
+		gitServer.StopHTTP()
+	})
+
+	// Create a git repo on the server.
+	branch := "main"
+	repoPath := "/config-" + rand.String(5) + ".git"
+	initRepo := testutil.InitGitRepo(g, gitServer, "testdata/appconfig", branch, repoPath)
+	repoURL := gitServer.HTTPAddressWithCredentials() + repoPath
+
+	// Add regular files, shared by both branches.
+	headMain := testutil.CommitInRepo(ctx, g, repoURL, branch, originRemote, "Add app config", func(tmp string) {
+		g.Expect(os.MkdirAll(filepath.Join(tmp, "deploy", "app1"), 0o755)).To(Succeed())
+		g.Expect(os.WriteFile(filepath.Join(tmp, "deploy", "app1", "config.yaml"), []byte("cfg: v1\n"), 0o644)).To(Succeed())
+		g.Expect(os.WriteFile(filepath.Join(tmp, "shared.yaml"), []byte("shared: v1\n"), 0o644)).To(Succeed())
+	})
+
+	// Create the push branch at the current head. It stays behind the
+	// checkout branch for the rest of the test.
+	pushBranch := "auto-" + rand.String(5)
+	g.Expect(initRepo.Storer.SetReference(
+		plumbing.NewHashReference(plumbing.NewBranchReferenceName(pushBranch), headMain))).To(Succeed())
+
+	// Restructure the checkout branch: replace deploy/app1/config.yaml
+	// with a symlink to the new deploy/_stacks/config.yaml, and add a
+	// symlink to the retained shared.yaml. The push branch predates the
+	// symlinks and their new target, so switching to it must delete them
+	// again.
+	testutil.CommitInRepo(ctx, g, repoURL, branch, originRemote, "Move config behind symlinks", func(tmp string) {
+		g.Expect(os.MkdirAll(filepath.Join(tmp, "deploy", "_stacks"), 0o755)).To(Succeed())
+		g.Expect(os.WriteFile(filepath.Join(tmp, "deploy", "_stacks", "config.yaml"), []byte("cfg: v2\n"), 0o644)).To(Succeed())
+		g.Expect(os.Remove(filepath.Join(tmp, "deploy", "app1", "config.yaml"))).To(Succeed())
+		g.Expect(os.Symlink("../_stacks/config.yaml", filepath.Join(tmp, "deploy", "app1", "config.yaml"))).To(Succeed())
+		g.Expect(os.Symlink("shared.yaml", filepath.Join(tmp, "link.yaml"))).To(Succeed())
+	})
+
+	// Create GitRepository and ImageUpdateAutomation checking out the
+	// main branch and pushing to the stale push branch.
+	gitRepo := &sourcev1.GitRepository{}
+	gitRepo.Name = "test-repo"
+	gitRepo.Namespace = testNS
+	gitRepo.Spec = sourcev1.GitRepositorySpec{
+		URL:       repoURL,
+		Reference: &sourcev1.GitRepositoryRef{Branch: branch},
+	}
+
+	updateAuto := &imagev1.ImageUpdateAutomation{}
+	updateAuto.Name = "test-update"
+	updateAuto.Namespace = testNS
+	updateAuto.Spec = imagev1.ImageUpdateAutomationSpec{
+		SourceRef: imagev1.CrossNamespaceSourceReference{
+			Kind: sourcev1.GitRepositoryKind,
+			Name: gitRepo.Name,
+		},
+		GitSpec: &imagev1.GitSpec{
+			Push: &imagev1.PushSpec{Branch: pushBranch},
+		},
+	}
+
+	kClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(gitRepo, updateAuto).
+		Build()
+
+	sm, err := NewSourceManager(ctx, kClient, updateAuto, WithSourceOptionGitAllBranchReferences())
+	g.Expect(err).ToNot(HaveOccurred())
+	defer func() {
+		g.Expect(sm.Cleanup()).ToNot(HaveOccurred())
+	}()
+
+	_, err = sm.CheckoutSource(ctx)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// The worktree must be on the push branch.
+	r, err := extgogit.PlainOpen(sm.WorkDirectory())
+	g.Expect(err).ToNot(HaveOccurred())
+	head, err := r.Head()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(head.Name().Short()).To(Equal(pushBranch))
+
+	// The worktree must match the push branch state: the config is a
+	// regular file again, the symlinks and their new target are gone,
+	// and the retained symlink target is untouched.
+	fi, err := os.Lstat(filepath.Join(sm.WorkDirectory(), "deploy", "app1", "config.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(fi.Mode() & os.ModeSymlink).To(BeZero())
+	content, err := os.ReadFile(filepath.Join(sm.WorkDirectory(), "deploy", "app1", "config.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(content)).To(Equal("cfg: v1\n"))
+
+	_, err = os.Lstat(filepath.Join(sm.WorkDirectory(), "deploy", "_stacks", "config.yaml"))
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+	_, err = os.Lstat(filepath.Join(sm.WorkDirectory(), "link.yaml"))
+	g.Expect(os.IsNotExist(err)).To(BeTrue())
+
+	content, err = os.ReadFile(filepath.Join(sm.WorkDirectory(), "shared.yaml"))
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(string(content)).To(Equal("shared: v1\n"))
+
+	// Nothing must be left to commit, so no stale files can end up on
+	// the push branch.
+	wt, err := r.Worktree()
+	g.Expect(err).ToNot(HaveOccurred())
+	status, err := wt.Status()
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(status.IsClean()).To(BeTrue(), "worktree not clean after branch switch: %v", status)
+}
+
 func TestSourceManager_CommitAndPush(t *testing.T) {
 	test_sourceManager_CommitAndPush(t, "http")
 	test_sourceManager_CommitAndPush(t, "ssh")

--- a/internal/source/worktree_fs.go
+++ b/internal/source/worktree_fs.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v5/util"
+	extgogit "github.com/go-git/go-git/v5"
+	gogitcache "github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+
+	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/git/gogit"
+)
+
+// worktreeFS wraps the billy.Filesystem used for the repository worktree
+// to work around go-git/go-billy#135: the BoundOS filesystem resolves a
+// trailing symlink path component, making Remove and RemoveAll operate
+// on the symlink target instead of the symlink itself.
+//
+// When switching to the push branch, go-git removes worktree files that
+// differ between the two branches. With the BoundOS behavior, removing
+// a symlink path deletes its target instead, and when the target has
+// already been deleted by a preceding change of the same checkout, the
+// removal fails with a "no such file or directory" error. This
+// permanently fails the reconciliation of an ImageUpdateAutomation with
+// a push branch that has fallen behind the checkout ref, until the push
+// branch is manually rebased or deleted.
+//
+// Remove and RemoveAll here operate on the given path itself, never on
+// the target it may link to, and treat removal of an already-absent
+// path as a no-op, matching `git checkout` semantics.
+//
+// The upstream fix exists only on the go-billy v6 (pre-release) line
+// and won't be backported to v5. This wrapper can be removed once
+// go-git and go-billy are bumped to v6.
+type worktreeFS struct {
+	billy.Filesystem
+	root string
+}
+
+// newWorktreeFS returns a filesystem rooted at the given path that is
+// safe for worktree file removals involving symlinks.
+func newWorktreeFS(root string) worktreeFS {
+	return worktreeFS{
+		Filesystem: osfs.New(root, osfs.WithBoundOS()),
+		root:       root,
+	}
+}
+
+// Remove deletes the named file, symlink or empty directory, without
+// following a trailing symlink. Removal of an already-absent path is a
+// no-op.
+func (fs worktreeFS) Remove(name string) error {
+	abs, ok, err := fs.securePath(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fs.Filesystem.Remove(name)
+	}
+	if err := os.Remove(abs); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// RemoveAll deletes the named path and any children it contains,
+// without following a trailing symlink. Removal of an already-absent
+// path is a no-op.
+func (fs worktreeFS) RemoveAll(name string) error {
+	abs, ok, err := fs.securePath(name)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return util.RemoveAll(fs.Filesystem, name)
+	}
+	return os.RemoveAll(abs)
+}
+
+// securePath maps name to an absolute path within the worktree root,
+// resolving intermediate symlinks like BoundOS does so relative paths
+// cannot escape the root, but keeping the final component unresolved so
+// that operations act on a trailing symlink itself rather than on its
+// target. It returns false for paths this wrapper does not handle (the
+// root itself, absolute paths, or a final ".." component), for which
+// callers fall back to the wrapped filesystem.
+func (fs worktreeFS) securePath(name string) (string, bool, error) {
+	if filepath.IsAbs(name) {
+		return "", false, nil
+	}
+	dir, base := filepath.Split(filepath.Clean(name))
+	if base == "" || base == "." || base == ".." {
+		return "", false, nil
+	}
+	parent, err := securejoin.SecureJoin(fs.root, dir)
+	if err != nil {
+		return "", false, err
+	}
+	return filepath.Join(parent, base), true, nil
+}
+
+// diskStorageClientOptions returns client options for storing the cloned
+// repository on disk at the given path, equivalent to
+// gogit.WithDiskStorage, but with the worktree filesystem wrapped in
+// worktreeFS.
+func diskStorageClientOptions(path string) ([]gogit.ClientOption, error) {
+	securePath, err := git.SecurePath(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path %s: %w", path, err)
+	}
+	dot := osfs.New(filepath.Join(securePath, extgogit.GitDirName), osfs.WithBoundOS())
+	return []gogit.ClientOption{
+		gogit.WithStorer(filesystem.NewStorage(dot, gogitcache.NewObjectLRUDefault())),
+		gogit.WithWorkTreeFS(newWorktreeFS(securePath)),
+	}, nil
+}

--- a/internal/source/worktree_fs_test.go
+++ b/internal/source/worktree_fs_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Flux authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestWorktreeFS_Remove(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(g *WithT, root string) (target string)
+		wantErr    bool
+		wantAbsent []string
+		wantExist  []string
+	}{
+		{
+			name: "regular file",
+			setup: func(g *WithT, root string) string {
+				g.Expect(os.WriteFile(filepath.Join(root, "file.yaml"), []byte("a"), 0o644)).To(Succeed())
+				return "file.yaml"
+			},
+			wantAbsent: []string{"file.yaml"},
+		},
+		{
+			name: "symlink keeps its target",
+			setup: func(g *WithT, root string) string {
+				g.Expect(os.MkdirAll(filepath.Join(root, "deploy", "_stacks"), 0o755)).To(Succeed())
+				g.Expect(os.MkdirAll(filepath.Join(root, "deploy", "app"), 0o755)).To(Succeed())
+				g.Expect(os.WriteFile(filepath.Join(root, "deploy", "_stacks", "config.yaml"), []byte("a"), 0o644)).To(Succeed())
+				g.Expect(os.Symlink("../_stacks/config.yaml", filepath.Join(root, "deploy", "app", "config.yaml"))).To(Succeed())
+				return "deploy/app/config.yaml"
+			},
+			wantAbsent: []string{"deploy/app/config.yaml"},
+			wantExist:  []string{"deploy/_stacks/config.yaml"},
+		},
+		{
+			name: "symlink with absent target",
+			setup: func(g *WithT, root string) string {
+				g.Expect(os.Symlink("missing.yaml", filepath.Join(root, "link.yaml"))).To(Succeed())
+				return "link.yaml"
+			},
+			wantAbsent: []string{"link.yaml"},
+		},
+		{
+			name: "absent path is a no-op",
+			setup: func(g *WithT, root string) string {
+				return "does/not/exist.yaml"
+			},
+		},
+		{
+			name: "root cannot be removed",
+			setup: func(g *WithT, root string) string {
+				return "."
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			root := t.TempDir()
+			target := tt.setup(g, root)
+
+			err := newWorktreeFS(root).Remove(target)
+			if tt.wantErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(HaveOccurred())
+			for _, p := range tt.wantAbsent {
+				_, err := os.Lstat(filepath.Join(root, p))
+				g.Expect(os.IsNotExist(err)).To(BeTrue(), "expected %s to be absent", p)
+			}
+			for _, p := range tt.wantExist {
+				_, err := os.Lstat(filepath.Join(root, p))
+				g.Expect(err).ToNot(HaveOccurred(), "expected %s to exist", p)
+			}
+		})
+	}
+}
+
+func TestWorktreeFS_Remove_cannotEscapeRoot(t *testing.T) {
+	g := NewWithT(t)
+
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	g.Expect(os.MkdirAll(root, 0o755)).To(Succeed())
+	outside := filepath.Join(base, "escape.yaml")
+	g.Expect(os.WriteFile(outside, []byte("a"), 0o644)).To(Succeed())
+
+	// The relative path is clamped to the root, like BoundOS does, and
+	// the resulting absent path is a no-op.
+	g.Expect(newWorktreeFS(root).Remove("../escape.yaml")).To(Succeed())
+	_, err := os.Lstat(outside)
+	g.Expect(err).ToNot(HaveOccurred(), "expected file outside the root to be untouched")
+}
+
+func TestWorktreeFS_RemoveAll(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(g *WithT, root string) (target string)
+		wantAbsent []string
+		wantExist  []string
+	}{
+		{
+			name: "directory with contents",
+			setup: func(g *WithT, root string) string {
+				g.Expect(os.MkdirAll(filepath.Join(root, "dir", "sub"), 0o755)).To(Succeed())
+				g.Expect(os.WriteFile(filepath.Join(root, "dir", "sub", "file.yaml"), []byte("a"), 0o644)).To(Succeed())
+				return "dir"
+			},
+			wantAbsent: []string{"dir"},
+		},
+		{
+			name: "symlink keeps its target",
+			setup: func(g *WithT, root string) string {
+				g.Expect(os.WriteFile(filepath.Join(root, "config.yaml"), []byte("a"), 0o644)).To(Succeed())
+				g.Expect(os.Symlink("config.yaml", filepath.Join(root, "link.yaml"))).To(Succeed())
+				return "link.yaml"
+			},
+			wantAbsent: []string{"link.yaml"},
+			wantExist:  []string{"config.yaml"},
+		},
+		{
+			name: "absent path is a no-op",
+			setup: func(g *WithT, root string) string {
+				return "does/not/exist.yaml"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			root := t.TempDir()
+			target := tt.setup(g, root)
+
+			g.Expect(newWorktreeFS(root).RemoveAll(target)).To(Succeed())
+			for _, p := range tt.wantAbsent {
+				_, err := os.Lstat(filepath.Join(root, p))
+				g.Expect(os.IsNotExist(err)).To(BeTrue(), "expected %s to be absent", p)
+			}
+			for _, p := range tt.wantExist {
+				_, err := os.Lstat(filepath.Join(root, p))
+				g.Expect(err).ToNot(HaveOccurred(), "expected %s to exist", p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1037

When an `ImageUpdateAutomation` uses a `push.branch` that has fallen behind the checkout ref and the changes between the two branches involve symlinks, `SwitchBranch` can fail with:

```
failed to checkout source: could not checkout to branch '<push-branch>':
remove <workdir>/<symlink-target>: no such file or directory
```

Once hit, every reconcile fails the same way until the push branch is manually rebased or deleted.

## Root cause

go-git/go-billy#135: go-billy v5's `osfs.BoundOS` resolves a trailing symlink path component (`BoundOS.abs` → `SecureJoin` walks every component, including the leaf), so `Remove`/`RemoveAll` on a symlink path operate on the symlink **target** instead of the symlink itself.

During the branch switch, go-git removes worktree files that differ between the two branches, in lexical path order. Two failure modes follow:

1. **Hard failure (this issue):** a path that is a symlink on the checkout ref but a regular file on the push branch is a `Modify` change, handled as `Remove` + re-create. `Remove` resolves the symlink to its target — which the same checkout has already deleted (e.g. `deploy/_stacks/config.yaml` sorts before `deploy/<service>/config.yaml`) — and fails with ENOENT. This reproduces the exact error in #1037, including the error naming the target path rather than the symlink being switched away from.
2. **Silent corruption:** when the removal resolves to a target that still exists, the target is deleted in place of the symlink. The stale symlink (untracked) and/or the missing tracked target then show up in `Status()` and get committed to the push branch by `CommitAndPush`.

The go-billy fix exists only on the v6 (pre-release) line and won't be backported to v5 (see maintainer comments on go-git/go-billy#135), so waiting for a dependency bump would leave affected automations wedged indefinitely. source-controller hits the same root cause in fluxcd/source-controller#1921.

## Fix

Wrap the worktree filesystem handed to the gogit client (`worktreeFS` in `internal/source/worktree_fs.go`): `Remove` and `RemoveAll` resolve intermediate path components securely like `BoundOS` does, but keep the final component unresolved so they operate on the path itself, never on a symlink target, and treat removal of an already-absent path as a no-op — matching `git checkout` semantics (and what go-billy v6 / `os.Root` do). Storage configuration moves from `buildGitConfig` to `CheckoutSource`, where the working directory is known.

The wrapper is entirely controller-side and can be dropped once go-git and go-billy are bumped to v6.

## Test plan

- New regression test `TestSourceManager_CheckoutSource_symlinkSwitchBranch` reproduces the scenario from the issue end-to-end (push branch behind the checkout ref, per-service config replaced by symlinks to a new `_stacks` file). On unpatched code it fails with the exact error from the issue (`could not checkout to branch '...': remove .../deploy/_stacks/config.yaml: no such file or directory`); with the fix the switch succeeds, the worktree matches the push branch state (symlink targets untouched, no stale symlinks) and is clean, so nothing bogus can be committed.
- New unit tests `TestWorktreeFS_*` cover symlink-preserving removal, no-op removal of absent paths, root protection, and that relative paths cannot escape the worktree root.
- [x] `go test -race ./internal/source/` passes
- [ ] `go test -race ./internal/controller/` (envtest) — tick after local verification
