### PR TITLE
fix: Deny force-update and deletion via Refspec

### DIFF
--- a/api/v1/git.go
+++ b/api/v1/git.go
@@ -138,8 +138,10 @@ type PushSpec struct {
 	// Refspec specifies the Git Refspec to use for a push operation.
 	// If both Branch and Refspec are provided, then the commit is pushed
 	// to the branch and also using the specified refspec.
+	// Refspecs that delete or force-update references are not supported.
 	// For more details about Git Refspecs, see:
 	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
+	// +kubebuilder:validation:Pattern="^$|^[^+:]"
 	// +optional
 	Refspec string `json:"refspec,omitempty"`
 

--- a/api/v1/git.go
+++ b/api/v1/git.go
@@ -138,7 +138,7 @@ type PushSpec struct {
 	// Refspec specifies the Git Refspec to use for a push operation.
 	// If both Branch and Refspec are provided, then the commit is pushed
 	// to the branch and also using the specified refspec.
-	// Refspecs that delete or force-update references are not supported.
+	// Deletion refspecs and refspecs prefixed with '+' are not supported.
 	// For more details about Git Refspecs, see:
 	// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 	// +kubebuilder:validation:Pattern="^$|^[^+:]"

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -210,8 +210,10 @@ spec:
                           Refspec specifies the Git Refspec to use for a push operation.
                           If both Branch and Refspec are provided, then the commit is pushed
                           to the branch and also using the specified refspec.
+                          Refspecs that delete or force-update references are not supported.
                           For more details about Git Refspecs, see:
                           https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
+                        pattern: ^$|^[^+:]
                         type: string
                     type: object
                 required:

--- a/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
+++ b/config/crd/bases/image.toolkit.fluxcd.io_imageupdateautomations.yaml
@@ -210,7 +210,7 @@ spec:
                           Refspec specifies the Git Refspec to use for a push operation.
                           If both Branch and Refspec are provided, then the commit is pushed
                           to the branch and also using the specified refspec.
-                          Refspecs that delete or force-update references are not supported.
+                          Deletion refspecs and refspecs prefixed with '+' are not supported.
                           For more details about Git Refspecs, see:
                           https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
                         pattern: ^$|^[^+:]

--- a/docs/api/v1/image-automation.md
+++ b/docs/api/v1/image-automation.md
@@ -786,7 +786,7 @@ string
 <p>Refspec specifies the Git Refspec to use for a push operation.
 If both Branch and Refspec are provided, then the commit is pushed
 to the branch and also using the specified refspec.
-Refspecs that delete or force-update references are not supported.
+Deletion refspecs and refspecs prefixed with &lsquo;+&rsquo; are not supported.
 For more details about Git Refspecs, see:
 <a href="https://git-scm.com/book/en/v2/Git-Internals-The-Refspec">https://git-scm.com/book/en/v2/Git-Internals-The-Refspec</a></p>
 </td>

--- a/docs/api/v1/image-automation.md
+++ b/docs/api/v1/image-automation.md
@@ -786,6 +786,7 @@ string
 <p>Refspec specifies the Git Refspec to use for a push operation.
 If both Branch and Refspec are provided, then the commit is pushed
 to the branch and also using the specified refspec.
+Refspecs that delete or force-update references are not supported.
 For more details about Git Refspecs, see:
 <a href="https://git-scm.com/book/en/v2/Git-Internals-The-Refspec">https://git-scm.com/book/en/v2/Git-Internals-The-Refspec</a></p>
 </td>

--- a/docs/spec/v1/imageupdateautomations.md
+++ b/docs/spec/v1/imageupdateautomations.md
@@ -603,6 +603,11 @@ spec:
 destination reference. An example of a valid refspec is
 `refs/heads/branch:refs/heads/branch`.
 
+Deletion refspecs with an empty source (for example,
+`:refs/heads/branch`) and force-update refspecs prefixed with `+` are not
+supported. Force pushing is limited to the configured push branch and is
+controlled by the [`GitForcePushBranch` feature gate](#branch).
+
 If both `.push.refspec` and `.push.branch` are specified, then the reconciler
 will push to both the destinations. This is particularly useful for working with
 Gerrit servers. For more information about this, please refer to the

--- a/docs/spec/v1/imageupdateautomations.md
+++ b/docs/spec/v1/imageupdateautomations.md
@@ -605,8 +605,8 @@ destination reference. An example of a valid refspec is
 
 Deletion refspecs with an empty source (for example,
 `:refs/heads/branch`) and force-update refspecs prefixed with `+` are not
-supported. Force pushing is limited to the configured push branch and is
-controlled by the [`GitForcePushBranch` feature gate](#branch).
+supported. Force pushing is controlled by the
+[`GitForcePushBranch` feature gate](#branch).
 
 If both `.push.refspec` and `.push.branch` are specified, then the reconciler
 will push to both the destinations. This is particularly useful for working with

--- a/internal/controller/imageupdateautomation_controller_test.go
+++ b/internal/controller/imageupdateautomation_controller_test.go
@@ -37,6 +37,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/otiai10/copy"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -106,6 +107,60 @@ Images:
 - helloworld:v1.0.0 (%s:%s)
 `
 )
+
+func TestImageUpdateAutomationRefspecValidation(t *testing.T) {
+	g := NewWithT(t)
+
+	namespace, err := testEnv.CreateNamespace(ctx, "refspec-validation")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() { g.Expect(testEnv.Delete(ctx, namespace)).To(Succeed()) }()
+
+	tests := []struct {
+		name    string
+		refspec string
+		valid   bool
+	}{
+		{name: "branch destination", refspec: "refs/heads/main:refs/heads/auto", valid: true},
+		{name: "Gerrit destination", refspec: "HEAD:refs/for/main", valid: true},
+		{name: "Gitea and Forgejo destination", refspec: "refs/heads/auto:refs/for/main", valid: true},
+		{name: "deletion", refspec: ":refs/heads/main"},
+		{name: "force update", refspec: "+refs/heads/main:refs/heads/auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			obj := &imagev1.ImageUpdateAutomation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "refspec-" + rand.String(5),
+					Namespace: namespace.Name,
+				},
+				Spec: imagev1.ImageUpdateAutomationSpec{
+					Interval: metav1.Duration{Duration: time.Hour},
+					SourceRef: imagev1.CrossNamespaceSourceReference{
+						Kind: sourcev1.GitRepositoryKind,
+						Name: "unused",
+					},
+					GitSpec: &imagev1.GitSpec{
+						Commit: imagev1.CommitSpec{
+							Author: imagev1.CommitUser{Email: "flux@example.com"},
+						},
+						Push: &imagev1.PushSpec{Refspec: tt.refspec},
+					},
+					Suspend: true,
+				},
+			}
+
+			err := k8sClient.Create(ctx, obj)
+			if tt.valid {
+				g.Expect(err).NotTo(HaveOccurred())
+				return
+			}
+			g.Expect(apierrors.IsInvalid(err)).To(BeTrue(), "expected invalid object error, got %v", err)
+			g.Expect(err.Error()).To(ContainSubstring("spec.git.push.refspec"))
+		})
+	}
+}
 
 func TestImageUpdateAutomationReconciler_deleteBeforeFinalizer(t *testing.T) {
 	g := NewWithT(t)

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/fluxcd/pkg/runtime/secrets"
@@ -50,6 +51,7 @@ type gitSrcCfg struct {
 	srcKey       types.NamespacedName
 	url          string
 	pushBranch   string
+	pushRefspec  string
 	switchBranch bool
 	timeout      *metav1.Duration
 	checkoutRef  *sourcev1.GitRepositoryRef
@@ -142,6 +144,17 @@ func buildGitConfig(ctx context.Context, c client.Client, originKey, srcKey type
 }
 
 func configurePush(cfg *gitSrcCfg, gitSpec *imagev1.GitSpec, checkoutRef *sourcev1.GitRepositoryRef) error {
+	if gitSpec.Push != nil {
+		refspec := gitSpec.Push.Refspec
+		switch {
+		case strings.HasPrefix(refspec, ":"):
+			return fmt.Errorf("push refspec must not specify a deletion: %w", ErrInvalidSourceConfiguration)
+		case strings.HasPrefix(refspec, "+"):
+			return fmt.Errorf("push refspec must not specify a force update: %w", ErrInvalidSourceConfiguration)
+		}
+		cfg.pushRefspec = refspec
+	}
+
 	if gitSpec.Push != nil && gitSpec.Push.Branch != "" {
 		cfg.pushBranch = gitSpec.Push.Branch
 

--- a/internal/source/git_test.go
+++ b/internal/source/git_test.go
@@ -18,6 +18,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -320,21 +321,23 @@ func Test_buildGitConfig(t *testing.T) {
 	testGitURL := "https://example.com"
 
 	tests := []struct {
-		name             string
-		gitSpec          *imagev1.GitSpec
-		gitRepoName      string
-		gitRepoRef       *sourcev1.GitRepositoryRef
-		gitRepoTimeout   *metav1.Duration
-		gitRepoURL       string
-		gitRepoProxyData map[string][]byte
-		srcOpts          SourceOptions
-		injectGetError   error
-		wantErr          bool
-		wantErrContains  string
-		wantCheckoutRef  *sourcev1.GitRepositoryRef
-		wantPushBranch   string
-		wantSwitchBranch bool
-		wantTimeout      *metav1.Duration
+		name                    string
+		gitSpec                 *imagev1.GitSpec
+		gitRepoName             string
+		gitRepoRef              *sourcev1.GitRepositoryRef
+		gitRepoTimeout          *metav1.Duration
+		gitRepoURL              string
+		gitRepoProxyData        map[string][]byte
+		srcOpts                 SourceOptions
+		injectGetError          error
+		wantErr                 bool
+		wantErrContains         string
+		wantCheckoutRef         *sourcev1.GitRepositoryRef
+		wantPushBranch          string
+		wantPushRefspec         string
+		wantSwitchBranch        bool
+		wantTimeout             *metav1.Duration
+		wantInvalidSourceConfig bool
 	}{
 		{
 			name: "same branch, gitSpec checkoutRef",
@@ -446,6 +449,56 @@ func Test_buildGitConfig(t *testing.T) {
 			wantPushBranch:   "bbb",
 			wantSwitchBranch: true,
 			wantTimeout:      testTimeout,
+		},
+		{
+			name: "valid explicit refspec",
+			gitSpec: &imagev1.GitSpec{
+				Checkout: &imagev1.GitCheckoutSpec{
+					Reference: sourcev1.GitRepositoryRef{Branch: "main"},
+				},
+				Push: &imagev1.PushSpec{
+					Refspec: "HEAD:refs/for/main",
+				},
+			},
+			gitRepoName:      testGitRepoName,
+			gitRepoURL:       testGitURL,
+			wantCheckoutRef:  &sourcev1.GitRepositoryRef{Branch: "main"},
+			wantPushBranch:   "main",
+			wantPushRefspec:  "HEAD:refs/for/main",
+			wantSwitchBranch: false,
+			wantTimeout:      testTimeout,
+		},
+		{
+			name: "deletion refspec",
+			gitSpec: &imagev1.GitSpec{
+				Checkout: &imagev1.GitCheckoutSpec{
+					Reference: sourcev1.GitRepositoryRef{Branch: "main"},
+				},
+				Push: &imagev1.PushSpec{
+					Refspec: ":refs/heads/main",
+				},
+			},
+			gitRepoName:             testGitRepoName,
+			gitRepoURL:              testGitURL,
+			wantErr:                 true,
+			wantErrContains:         "push refspec must not specify a deletion",
+			wantInvalidSourceConfig: true,
+		},
+		{
+			name: "force-update refspec",
+			gitSpec: &imagev1.GitSpec{
+				Checkout: &imagev1.GitCheckoutSpec{
+					Reference: sourcev1.GitRepositoryRef{Branch: "main"},
+				},
+				Push: &imagev1.PushSpec{
+					Refspec: "+refs/heads/main:refs/heads/auto",
+				},
+			},
+			gitRepoName:             testGitRepoName,
+			gitRepoURL:              testGitURL,
+			wantErr:                 true,
+			wantErrContains:         "push refspec must not specify a force update",
+			wantInvalidSourceConfig: true,
 		},
 		{
 			name:    "non-existing gitRepo",
@@ -586,9 +639,13 @@ func Test_buildGitConfig(t *testing.T) {
 			if tt.wantErrContains != "" {
 				g.Expect(err.Error()).To(ContainSubstring(tt.wantErrContains))
 			}
+			if tt.wantInvalidSourceConfig {
+				g.Expect(errors.Is(err, ErrInvalidSourceConfiguration)).To(BeTrue())
+			}
 			if err == nil {
 				g.Expect(gitSrcCfg.checkoutRef).To(Equal(tt.wantCheckoutRef), "unexpected checkoutRef")
 				g.Expect(gitSrcCfg.pushBranch).To(Equal(tt.wantPushBranch), "unexpected push branch")
+				g.Expect(gitSrcCfg.pushRefspec).To(Equal(tt.wantPushRefspec), "unexpected push refspec")
 				g.Expect(gitSrcCfg.switchBranch).To(Equal(tt.wantSwitchBranch), "unexpected switch branch")
 				g.Expect(gitSrcCfg.timeout).To(Equal(tt.wantTimeout), "unexpected git operation timeout")
 			}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -284,6 +284,16 @@ func WithPushConfigForce() PushConfig {
 	}
 }
 
+// buildRefspecPushConfig returns a push configuration for an explicit refspec.
+// Force is deliberately not inherited because it is authorized only for the
+// configured push branch.
+func buildRefspecPushConfig(branchConfig repository.PushConfig, refspec string) repository.PushConfig {
+	return repository.PushConfig{
+		Refspecs: []string{refspec},
+		Options:  branchConfig.Options,
+	}
+}
+
 // WithPushConfigOptions configures the PushConfig Options that are used in
 // push.
 func WithPushConfigOptions(opts map[string]string) PushConfig {
@@ -353,17 +363,20 @@ func (sm SourceManager) CommitAndPush(ctx context.Context, obj *imagev1.ImageUpd
 	}
 	tracelog.Info("pushed commit to push branch", "revision", rev, "branch", sm.srcCfg.pushBranch)
 
-	// Push to any provided refspec.
-	if obj.Spec.GitSpec.HasRefspec() {
-		pushConfig.Refspecs = append(pushConfig.Refspecs, obj.Spec.GitSpec.Push.Refspec)
-		if err := sm.gitClient.Push(gitOpCtx, pushConfig); err != nil {
+	// Push to any provided refspec without inheriting force from the branch
+	// push, as force is only authorized for the configured push branch.
+	var pushedRefspecs []string
+	if sm.srcCfg.pushRefspec != "" {
+		refspecPushConfig := buildRefspecPushConfig(pushConfig, sm.srcCfg.pushRefspec)
+		if err := sm.gitClient.Push(gitOpCtx, refspecPushConfig); err != nil {
 			return nil, err
 		}
-		tracelog.Info("pushed commit to refspec", "revision", rev, "refspecs", pushConfig.Refspecs)
+		pushedRefspecs = refspecPushConfig.Refspecs
+		tracelog.Info("pushed commit to refspec", "revision", rev, "refspecs", pushedRefspecs)
 	}
 
 	// Construct the result of the push operation and return.
-	prOpts := []PushResultOption{WithPushResultRefspec(pushConfig.Refspecs)}
+	prOpts := []PushResultOption{WithPushResultRefspec(pushedRefspecs)}
 	if sm.srcCfg.switchBranch {
 		prOpts = append(prOpts, WithPushResultSwitchBranch())
 	}

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -285,13 +285,9 @@ func WithPushConfigForce() PushConfig {
 }
 
 // buildRefspecPushConfig returns a push configuration for an explicit refspec.
-// Force is deliberately not inherited because it is authorized only for the
-// configured push branch.
-func buildRefspecPushConfig(branchConfig repository.PushConfig, refspec string) repository.PushConfig {
-	return repository.PushConfig{
-		Refspecs: []string{refspec},
-		Options:  branchConfig.Options,
-	}
+func buildRefspecPushConfig(pushConfig repository.PushConfig, refspec string) repository.PushConfig {
+	pushConfig.Refspecs = []string{refspec}
+	return pushConfig
 }
 
 // WithPushConfigOptions configures the PushConfig Options that are used in
@@ -363,8 +359,7 @@ func (sm SourceManager) CommitAndPush(ctx context.Context, obj *imagev1.ImageUpd
 	}
 	tracelog.Info("pushed commit to push branch", "revision", rev, "branch", sm.srcCfg.pushBranch)
 
-	// Push to any provided refspec without inheriting force from the branch
-	// push, as force is only authorized for the configured push branch.
+	// Push to any provided refspec.
 	var pushedRefspecs []string
 	if sm.srcCfg.pushRefspec != "" {
 		refspecPushConfig := buildRefspecPushConfig(pushConfig, sm.srcCfg.pushRefspec)

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -1170,19 +1170,31 @@ func test_pushBranchUpdateScenarios(t *testing.T, proto string, srcOpts []Source
 }
 
 func Test_buildRefspecPushConfig(t *testing.T) {
-	g := NewWithT(t)
-	options := map[string]string{"topic": "flux-updates"}
-	branchConfig := repository.PushConfig{
-		Refspecs: []string{"refs/heads/main:refs/heads/auto"},
-		Force:    true,
-		Options:  options,
+	tests := []struct {
+		name  string
+		force bool
+	}{
+		{name: "force disabled"},
+		{name: "force enabled", force: true},
 	}
 
-	refspecConfig := buildRefspecPushConfig(branchConfig, "HEAD:refs/for/main")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			options := map[string]string{"topic": "flux-updates"}
+			branchConfig := repository.PushConfig{
+				Refspecs: []string{"refs/heads/main:refs/heads/auto"},
+				Force:    tt.force,
+				Options:  options,
+			}
 
-	g.Expect(refspecConfig.Refspecs).To(Equal([]string{"HEAD:refs/for/main"}))
-	g.Expect(refspecConfig.Force).To(BeFalse())
-	g.Expect(refspecConfig.Options).To(Equal(options))
+			refspecConfig := buildRefspecPushConfig(branchConfig, "HEAD:refs/for/main")
+
+			g.Expect(refspecConfig.Refspecs).To(Equal([]string{"HEAD:refs/for/main"}))
+			g.Expect(refspecConfig.Force).To(Equal(tt.force))
+			g.Expect(refspecConfig.Options).To(Equal(options))
+		})
+	}
 }
 
 func TestPushResult_Summary(t *testing.T) {

--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -47,6 +47,7 @@ import (
 	reflectorv1 "github.com/fluxcd/image-reflector-controller/api/v1"
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/git"
+	"github.com/fluxcd/pkg/git/repository"
 	"github.com/fluxcd/pkg/gittestserver"
 	"github.com/fluxcd/pkg/ssh"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -1166,6 +1167,22 @@ func test_pushBranchUpdateScenarios(t *testing.T, proto string, srcOpts []Source
 	oldCommit, err = localRepo.CommitObject(checkoutBranchHead.Hash)
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(oldCommit).ToNot(BeNil())
+}
+
+func Test_buildRefspecPushConfig(t *testing.T) {
+	g := NewWithT(t)
+	options := map[string]string{"topic": "flux-updates"}
+	branchConfig := repository.PushConfig{
+		Refspecs: []string{"refs/heads/main:refs/heads/auto"},
+		Force:    true,
+		Options:  options,
+	}
+
+	refspecConfig := buildRefspecPushConfig(branchConfig, "HEAD:refs/for/main")
+
+	g.Expect(refspecConfig.Refspecs).To(Equal([]string{"HEAD:refs/for/main"}))
+	g.Expect(refspecConfig.Force).To(BeFalse())
+	g.Expect(refspecConfig.Options).To(Equal(options))
 }
 
 func TestPushResult_Summary(t *testing.T) {


### PR DESCRIPTION
Prevent deletion via refspecs with an empty source and force pushing without setting the `GitForcePushBranch` feature gate.